### PR TITLE
v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,14 @@
+# v0.3.0
+
+* add: `--no-base64` switch to disable for test/debug (base64 stream tags)
+* add: `--no-gzip` switch to disable for test/debug (gzip trap submissions)
+* upd: switch to using gzip compression for trap submissions as default
+* fix: stream tag quote escaping in printf
+
 # v0.2.0
 
-* abridged events
-* pod filtering by label key/val
+* add: abridged events
+* add: pod filtering by label key/val
 
 # v0.1.0
 

--- a/cmd/args_circonus.go
+++ b/cmd/args_circonus.go
@@ -287,11 +287,11 @@ func init() {
 
 	{
 		const (
-			key          = keys.Base64Tags
-			longOpt      = "base64-tags"
-			envVar       = release.ENVPREFIX + "_BASE64_TAGS"
-			description  = "Use base64 encoding for stream tags"
-			defaultValue = defaults.Base64Tags
+			key          = keys.NoBase64
+			longOpt      = "no-base64"
+			envVar       = release.ENVPREFIX + "_NO_BASE64"
+			description  = "Disable base64 encoding for stream tags"
+			defaultValue = defaults.NoBase64
 		)
 
 		rootCmd.PersistentFlags().Bool(longOpt, defaultValue, envDescription(description, envVar))
@@ -350,11 +350,11 @@ func init() {
 
 	{
 		const (
-			key          = keys.UseGZIP
-			longOpt      = "use-gzip"
-			envVar       = release.ENVPREFIX + "_USE_GZIP"
-			description  = "Enable gzip compression when submitting metrics"
-			defaultValue = defaults.UseGZIP
+			key          = keys.NoGZIP
+			longOpt      = "no-gzip"
+			envVar       = release.ENVPREFIX + "_NO_GZIP"
+			description  = "Disable gzip compression when submitting metrics"
+			defaultValue = defaults.NoGZIP
 		)
 
 		rootCmd.PersistentFlags().Bool(longOpt, defaultValue, envDescription(description, envVar))

--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -5,28 +5,28 @@
     name: circonus-kubernetes-agent
     labels:
       app.kubernetes.io/name: circonus-kubernetes-agent
-      app.kubernetes.io/version: v0.2.0
+      app.kubernetes.io/version: v0.3.0
   spec:
     selector:
       matchLabels:
         app.kubernetes.io/name: circonus-kubernetes-agent
-        app.kubernetes.io/version: v0.2.0
+        app.kubernetes.io/version: v0.3.0
     replicas: 1
     template:
       metadata:
         name: circonus-kubernetes-agent
         labels:
           app.kubernetes.io/name: circonus-kubernetes-agent
-          app.kubernetes.io/version: v0.2.0
+          app.kubernetes.io/version: v0.3.0
       spec:
         nodeSelector:
           kubernetes.io/os: linux
         serviceAccountName: circonus-kubernetes-agent
         containers:
           - name: circonus-kubernetes-agent
-            image: circonuslabs/circonus-kubernetes-agent:v0.2.0
+            image: circonuslabs/circonus-kubernetes-agent:v0.3.0
             ## for ARM64, remove line above and uncomment line below
-            #image: circonuslabs/circonus-kubernetes-agent-arm64:v0.2.0
+            #image: circonuslabs/circonus-kubernetes-agent-arm64:v0.3.0
             command: ["/circonus-kubernetes-agentd"]
             args: 
               #- --debug

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/circonus-labs/circonus-kubernetes-agent/internal/cluster"
 	"github.com/circonus-labs/circonus-kubernetes-agent/internal/config"
+	"github.com/circonus-labs/circonus-kubernetes-agent/internal/config/defaults"
 	"github.com/circonus-labs/circonus-kubernetes-agent/internal/config/keys"
 	"github.com/circonus-labs/circonus-kubernetes-agent/internal/release"
 	"github.com/pkg/errors"
@@ -60,10 +61,16 @@ func New() (*Agent, error) {
 	}
 
 	// Set the hidden settings based on viper
-	cfg.Circonus.Base64Tags = viper.GetBool(keys.Base64Tags)
+	cfg.Circonus.Base64Tags = defaults.Base64Tags
+	if viper.GetBool(keys.NoBase64) {
+		cfg.Circonus.Base64Tags = false
+	}
+	cfg.Circonus.UseGZIP = defaults.UseGZIP
+	if viper.GetBool(keys.NoGZIP) {
+		cfg.Circonus.UseGZIP = false
+	}
 	cfg.Circonus.DryRun = viper.GetBool(keys.DryRun)
 	cfg.Circonus.StreamMetrics = viper.GetBool(keys.StreamMetrics)
-	cfg.Circonus.UseGZIP = viper.GetBool(keys.UseGZIP)
 
 	if len(cfg.Clusters) > 0 { // multiple clusters
 		for _, clusterConfig := range cfg.Clusters {

--- a/internal/circonus/check.go
+++ b/internal/circonus/check.go
@@ -63,14 +63,14 @@ func NewCheck(parentLogger zerolog.Logger, cfg *config.Circonus) (*Check, error)
 	if cfg.Base64Tags != defaults.Base64Tags {
 		c.log.Debug().Bool("enabled", cfg.Base64Tags).Msg("base64 tag encoding")
 	}
+	if cfg.UseGZIP != defaults.UseGZIP {
+		c.log.Debug().Bool("enabled", cfg.UseGZIP).Msg("gzip submit compression")
+	}
 	if cfg.DryRun != defaults.DryRun {
 		c.log.Debug().Bool("enabled", cfg.DryRun).Msg("dry run")
 	}
 	if cfg.StreamMetrics != defaults.StreamMetrics {
 		c.log.Debug().Bool("enabled", cfg.StreamMetrics).Msg("streaming metrics format")
-	}
-	if cfg.UseGZIP != defaults.UseGZIP {
-		c.log.Debug().Bool("enabled", cfg.UseGZIP).Msg("gzip content encoding for metrics")
 	}
 
 	if cfg.DryRun {

--- a/internal/circonus/tags.go
+++ b/internal/circonus/tags.go
@@ -85,7 +85,7 @@ func encodeTags(tags []string, useBase64 bool) string {
 		tagList[i] = tc + ":" + tv
 	}
 
-	return fmt.Sprintf("%q", strings.Join(tagList, ","))
+	return strings.Join(tagList, ",")
 }
 
 func removeSpaces(r rune) rune {

--- a/internal/config/defaults/defaults.go
+++ b/internal/config/defaults/defaults.go
@@ -33,10 +33,14 @@ const (
 	CheckTitle         = ""
 	TraceSubmits       = ""
 	// hidden circonus settings for development and debugging
-	Base64Tags    = true
 	DryRun        = false
 	StreamMetrics = false
-	UseGZIP       = false
+	// these hidden settings are mainly for debugging
+	// the features default to ON and can be toggled OFF
+	NoBase64   = false
+	Base64Tags = true
+	NoGZIP     = false
+	UseGZIP    = true
 
 	// General defaults
 

--- a/internal/config/keys/keys.go
+++ b/internal/config/keys/keys.go
@@ -85,6 +85,8 @@ const (
 
 	// Base64Tags whether to encode tags with base64
 	Base64Tags = "circonus.base64_tags"
+	// NoBase64 disables using base64 encoding for stream tags (debugging)
+	NoBase64 = "circonus.no_base64"
 
 	// DryRun print metrics to stdout rather than sending to circonu
 	DryRun = "circonus.dry_run"
@@ -94,6 +96,8 @@ const (
 
 	// UseGZIP when submitting
 	UseGZIP = "circonus.use_gzip"
+	// NoGZIP disables using compression for submits
+	NoGZIP = "circonus.no_gzip"
 
 	//
 	// Kubernetes cluster (single, use either kubernetes or clusters, not both)


### PR DESCRIPTION
* add: `--no-base64` switch to disable for test/debug (base64 stream tags)
* add: `--no-gzip` switch to disable for test/debug (gzip trap submissions)
* upd: switch to using gzip compression for trap submissions as default
* fix: stream tag quote escaping in printf
