### PR TITLE
v0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v0.4.3
+
+* upd: metric filter rule to include storage `capacity` for pod volumes
+* add: per-interface network metrics
+* add: node `capacity_ephemeral_storage` metric
+
 # v0.4.2
 
 * add: node capacity metrtics: `capacity_cpu`, `capacity_memory`, and `capacity_pods`

--- a/deploy/configuration.yaml
+++ b/deploy/configuration.yaml
@@ -88,7 +88,7 @@
         {
           "metric_filters": [
             ["allow","^[rt]x$","tags","and(resource:network,or(units:bytes,units::errors),not(container_name:*),not(sys_container:*))","utilization"],
-            ["allow","^used$","tags","and(units:bytes,or(resource:memory,resource:fs,volume_name:*),not(container_name:*),not(sys_container:*))","utilization"],
+            ["allow","^(used|capacity)$","tags","and(units:bytes,or(resource:memory,resource:fs,volume_name:*),not(container_name:*),not(sys_container:*))","utilization"],
             ["allow","^usageNanoCores$","tags","and(not(container_name:*),not(sys_container:*))","utilization"],
             ["allow","^kube_pod_container_status_(running|terminated|waiting|ready)$","containers"],
             ["allow","^kube_deployment_(created|spec_replicas|status_replicas|status_replicas_updated|status_replicas_available|status_replicas_unavailable)$","deployments"],

--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -5,28 +5,28 @@
     name: circonus-kubernetes-agent
     labels:
       app.kubernetes.io/name: circonus-kubernetes-agent
-      app.kubernetes.io/version: v0.4.2
+      app.kubernetes.io/version: v0.4.3
   spec:
     selector:
       matchLabels:
         app.kubernetes.io/name: circonus-kubernetes-agent
-        app.kubernetes.io/version: v0.4.2
+        app.kubernetes.io/version: v0.4.3
     replicas: 1
     template:
       metadata:
         name: circonus-kubernetes-agent
         labels:
           app.kubernetes.io/name: circonus-kubernetes-agent
-          app.kubernetes.io/version: v0.4.2
+          app.kubernetes.io/version: v0.4.3
       spec:
         nodeSelector:
           kubernetes.io/os: linux
         serviceAccountName: circonus-kubernetes-agent
         containers:
           - name: circonus-kubernetes-agent
-            image: circonuslabs/circonus-kubernetes-agent:v0.4.2
+            image: circonuslabs/circonus-kubernetes-agent:v0.4.3
             ## for ARM64, remove line above and uncomment line below
-            #image: circonuslabs/circonus-kubernetes-agent-arm64:v0.4.2
+            #image: circonuslabs/circonus-kubernetes-agent-arm64:v0.4.3
             command: ["/circonus-kubernetes-agentd"]
             args: 
               #- --debug

--- a/internal/k8s/node.go
+++ b/internal/k8s/node.go
@@ -28,9 +28,10 @@ type NodeStatus struct {
 }
 
 type NodeSizes struct {
-	CPU    string `json:"cpu"`
-	Memory string `json:"memory"`
-	Pods   string `json:"pods"`
+	CPU              string `json:"cpu"`
+	Memory           string `json:"memory"`
+	Pods             string `json:"pods"`
+	EphemeralStorage string `json:"ephemeral-storage"`
 }
 
 type NodeCondition struct {

--- a/internal/nodes/collector/collector.go
+++ b/internal/nodes/collector/collector.go
@@ -183,6 +183,20 @@ func (nc *Collector) meta(parentStreamTags []string, parentMeasurementTags []str
 			} else {
 				nc.log.Warn().Err(err).Str("memory", nc.node.Status.Capacity.Memory).Msg("parsing quantity capacity.memory")
 			}
+			if qty, err := resource.ParseQuantity(nc.node.Status.Capacity.EphemeralStorage); err == nil {
+				if storage, ok := qty.AsInt64(); ok {
+					streamTags = append(streamTags, "units:bytes")
+					_ = nc.check.WriteMetricSample(
+						&buf,
+						"capacity_ephemeral_storage",
+						circonus.MetricTypeUint64,
+						streamTags, parentMeasurementTags,
+						uint64(storage),
+						nil)
+				}
+			} else {
+				nc.log.Warn().Err(err).Str("ephemeral_storage", nc.node.Status.Capacity.EphemeralStorage).Msg("parsing quantity capacity.ephemeral-storage")
+			}
 		}
 
 		if buf.Len() == 0 {
@@ -273,6 +287,20 @@ func (nc *Collector) meta(parentStreamTags []string, parentMeasurementTags []str
 			}
 		} else {
 			nc.log.Warn().Err(err).Str("memory", nc.node.Status.Capacity.Memory).Msg("parsing quantity capacity.memory")
+		}
+		if qty, err := resource.ParseQuantity(nc.node.Status.Capacity.EphemeralStorage); err == nil {
+			if storage, ok := qty.AsInt64(); ok {
+				streamTags = append(streamTags, "units:bytes")
+				_ = nc.check.QueueMetricSample(
+					metrics,
+					"capacity_ephemeral_storage",
+					circonus.MetricTypeUint64,
+					streamTags, parentMeasurementTags,
+					uint64(storage),
+					nil)
+			}
+		} else {
+			nc.log.Warn().Err(err).Str("ephemeral_storage", nc.node.Status.Capacity.EphemeralStorage).Msg("parsing quantity capacity.ephemeral-storage")
 		}
 	}
 

--- a/internal/nodes/collector/metrics.go
+++ b/internal/nodes/collector/metrics.go
@@ -105,6 +105,23 @@ func (nc *Collector) queueNetwork(dest map[string]circonus.MetricSample, stats *
 		_ = nc.check.QueueMetricSample(dest, receive, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, stats.RxErrors, nil)
 		_ = nc.check.QueueMetricSample(dest, transmit, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, stats.TxErrors, nil)
 	}
+
+	for _, iface := range stats.Interfaces {
+		{ // units:bytes
+			var streamTags []string
+			streamTags = append(streamTags, parentStreamTags...)
+			streamTags = append(streamTags, []string{"resource:network", "units:bytes", "interface:" + iface.Name}...)
+			_ = nc.check.QueueMetricSample(dest, receive, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, iface.RxBytes, nil)
+			_ = nc.check.QueueMetricSample(dest, transmit, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, iface.TxBytes, nil)
+		}
+		{ // units:errors
+			var streamTags []string
+			streamTags = append(streamTags, parentStreamTags...)
+			streamTags = append(streamTags, []string{"resource:network", "units:errors", "interface:" + iface.Name}...)
+			_ = nc.check.QueueMetricSample(dest, receive, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, iface.RxErrors, nil)
+			_ = nc.check.QueueMetricSample(dest, transmit, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, iface.TxErrors, nil)
+		}
+	}
 }
 
 func (nc *Collector) streamNetwork(dest io.Writer, stats *network, parentStreamTags []string, parentMeasurementTags []string) {
@@ -124,6 +141,22 @@ func (nc *Collector) streamNetwork(dest io.Writer, stats *network, parentStreamT
 		streamTags = append(streamTags, []string{"resource:network", "units:errors"}...)
 		_ = nc.check.WriteMetricSample(dest, receive, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, stats.RxErrors, nc.ts)
 		_ = nc.check.WriteMetricSample(dest, transmit, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, stats.TxErrors, nc.ts)
+	}
+	for _, iface := range stats.Interfaces {
+		{ // units:bytes
+			var streamTags []string
+			streamTags = append(streamTags, parentStreamTags...)
+			streamTags = append(streamTags, []string{"resource:network", "units:bytes", "interface:" + iface.Name}...)
+			_ = nc.check.WriteMetricSample(dest, receive, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, iface.RxBytes, nil)
+			_ = nc.check.WriteMetricSample(dest, transmit, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, iface.TxBytes, nil)
+		}
+		{ // units:errors
+			var streamTags []string
+			streamTags = append(streamTags, parentStreamTags...)
+			streamTags = append(streamTags, []string{"resource:network", "units:errors", "interface:" + iface.Name}...)
+			_ = nc.check.WriteMetricSample(dest, receive, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, iface.RxErrors, nil)
+			_ = nc.check.WriteMetricSample(dest, transmit, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, iface.TxErrors, nil)
+		}
 	}
 }
 


### PR DESCRIPTION
* upd: metric filter rule to include storage `capacity` for pod volumes
* add: per-interface network metrics
* add: node `capacity_ephemeral_storage` metric
