### PR TITLE
v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# v0.5.0
+
+* add: logging on submit retries and non-200 responses
+* add: api request timelimit (default:10s)
+* add: `kube_pod_deleted` to metric filters
+* add: agent metric
+* add: api request error metrics
+* add: collection duration, api latency, and metric submission latency histograms
+* upd: failure message when cluster(s) can't be initialized resulting in 0 clusters
+* fix: ensure default tags used in queued metrics
+
 # v0.4.5
 
 * fix: handle empty tag lists better, e.g. events with no tags

--- a/cmd/args_kubernetes.go
+++ b/cmd/args_kubernetes.go
@@ -358,4 +358,24 @@ func init() {
 		}
 		viper.SetDefault(key, defaultValue)
 	}
+
+	{
+		const (
+			key          = keys.K8SAPITimelimit
+			longOpt      = "k8s-api-timelimit"
+			envVar       = release.ENVPREFIX + "_K8S_API_TIMELIMIT"
+			description  = "Kubernetes API request timelimit"
+			defaultValue = defaults.K8SAPITimelimit
+		)
+
+		rootCmd.PersistentFlags().String(longOpt, defaultValue, envDescription(description, envVar))
+		if err := viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)); err != nil {
+			bindFlagError(longOpt, err)
+		}
+		if err := viper.BindEnv(key, envVar); err != nil {
+			bindEnvError(envVar, err)
+		}
+		viper.SetDefault(key, defaultValue)
+	}
+
 }

--- a/deploy/configuration.yaml
+++ b/deploy/configuration.yaml
@@ -101,7 +101,7 @@
             ["allow","^kube_pod_start_time","pods"],
             ["allow","^kube_pod_status_phase$","tags","and(or(phase:Running,phase:Pending,phase:Failed,phase:Succeeded))","pods"],
             ["allow","^kube_pod_status_(ready|scheduled)$","tags","and(condition:true)","pods"],
-            ["allow","^kube_(service_labels|deployment_labels|pod_container_info)$","ksm inventory"],
+            ["allow","^kube_(service_labels|deployment_labels|pod_container_info|pod_deleted)$","ksm inventory"],
             ["allow","^(node|kubelet_running_pod_count|Ready)$","nodes"],
             ["allow","^NetworkUnavailable$","node status"],
             ["allow","^(Disk|Memory|PID)Pressure$","node status"],

--- a/deploy/configuration.yaml
+++ b/deploy/configuration.yaml
@@ -86,6 +86,8 @@
       ## collection interval, how often to collect metrics (note if a previous 
       ## collection is still in progress another will NOT be started)
       #kubernetes-collection-interval: "1m"
+      ## api request timelimit
+      #kubernetes-api-timelimit: "10s"
       ##
       ## Metric filters control which metrics are passed on by the broker
       ## NOTE: This list ONLY applies when initially creating a check. After a

--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -5,28 +5,28 @@
     name: circonus-kubernetes-agent
     labels:
       app.kubernetes.io/name: circonus-kubernetes-agent
-      app.kubernetes.io/version: v0.4.5
+      app.kubernetes.io/version: v0.5.0
   spec:
     selector:
       matchLabels:
         app.kubernetes.io/name: circonus-kubernetes-agent
-        app.kubernetes.io/version: v0.4.5
+        app.kubernetes.io/version: v0.5.0
     replicas: 1
     template:
       metadata:
         name: circonus-kubernetes-agent
         labels:
           app.kubernetes.io/name: circonus-kubernetes-agent
-          app.kubernetes.io/version: v0.4.5
+          app.kubernetes.io/version: v0.5.0
       spec:
         nodeSelector:
           kubernetes.io/os: linux
         serviceAccountName: circonus-kubernetes-agent
         containers:
           - name: circonus-kubernetes-agent
-            image: circonuslabs/circonus-kubernetes-agent:v0.4.5
+            image: circonuslabs/circonus-kubernetes-agent:v0.5.0
             ## for ARM64, remove line above and uncomment line below
-            #image: circonuslabs/circonus-kubernetes-agent-arm64:v0.4.5
+            #image: circonuslabs/circonus-kubernetes-agent-arm64:v0.5.0
             command: ["/circonus-kubernetes-agentd"]
             args: 
               #- --debug

--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -196,6 +196,11 @@
               #     configMapKeyRef:
               #       name: cka-config-v1
               #       key: kubernetes-collection-interval
+              # - name: CKA_K8S_API_TIMELIMIT
+              #   valueFrom:
+              #     configMapKeyRef:
+              #       name: cka-config-v1
+              #       key: kubernetes-api-timelimit
             resources:
               requests:
                 memory: "64Mi"

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.13
 require (
 	code.cloudfoundry.org/bytefmt v0.0.0-20200131002437-cf55d5288a48
 	github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d
+	github.com/circonus-labs/circonus-gometrics/v3 v3.0.0
 	github.com/circonus-labs/go-apiclient v0.7.2
 	github.com/gogo/protobuf v1.3.1 // indirect
 	github.com/golang/protobuf v1.3.3 // indirect
@@ -19,7 +20,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common v0.9.1
-	github.com/rs/zerolog v1.17.2
+	github.com/rs/zerolog v1.18.0
 	github.com/spf13/cast v1.3.1 // indirect
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -27,6 +27,11 @@ github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
+github.com/circonus-labs/circonus-gometrics/v3 v3.0.0 h1:5hbWwgfrYaSNCe+eKPGo457QiCe4T5+CfvY+bFGZBNw=
+github.com/circonus-labs/circonus-gometrics/v3 v3.0.0/go.mod h1:1K33fx/wP96fC1uc7ZEp3BoLafJhL0kpjejIXpQHyLM=
+github.com/circonus-labs/circonusllhist v0.1.3 h1:TJH+oke8D16535+jHExHj4nQvzlZrj7ug5D7I/orNUA=
+github.com/circonus-labs/circonusllhist v0.1.3/go.mod h1:kMXHVDlOchFAehlya5ePtbp5jckzBHf4XRpQvBOLI+I=
+github.com/circonus-labs/go-apiclient v0.6.6/go.mod h1:4LZCGA0xxWyajgjb/mMIoKjnyR4dAx+UmrhBaE0lOio=
 github.com/circonus-labs/go-apiclient v0.7.2 h1:dOxqHbbtBb7yZ/R2i1VqIZxKCP7ki9Kct07GXyV97KU=
 github.com/circonus-labs/go-apiclient v0.7.2/go.mod h1:RP/BcaTRf8MlHaMGCSuSDPGPQqyMeBxaAdwNv5CM/eQ=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
@@ -218,8 +223,8 @@ github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsT
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
-github.com/rs/zerolog v1.17.2 h1:RMRHFw2+wF7LO0QqtELQwo8hqSmqISyCJeFeAAuWcRo=
-github.com/rs/zerolog v1.17.2/go.mod h1:9nvC1axdVrAHcu/s9taAVfBuIdTZLVQmKQyvrUjF5+I=
+github.com/rs/zerolog v1.18.0 h1:CbAm3kP2Tptby1i9sYy2MGRg0uxIN9cyDb59Ys7W8z8=
+github.com/rs/zerolog v1.18.0/go.mod h1:9nvC1axdVrAHcu/s9taAVfBuIdTZLVQmKQyvrUjF5+I=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
@@ -262,6 +267,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
+github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926 h1:G3dpKMzFDjgEh2q1Z7zUUtKa8ViPtH+ocF0bE0g00O8=
+github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -93,7 +93,7 @@ func New() (*Agent, error) {
 	}
 
 	if len(a.clusters) == 0 {
-		log.Fatal().Msg("no cluster(s) configured, must configure at least ONE")
+		log.Fatal().Msg("no cluster(s) initialized")
 	}
 
 	a.signalNotifySetup()

--- a/internal/circonus/metrics.go
+++ b/internal/circonus/metrics.go
@@ -12,6 +12,8 @@ import (
 	"regexp"
 	"strings"
 	"time"
+
+	cgm "github.com/circonus-labs/circonus-gometrics/v3"
 )
 
 const (
@@ -70,6 +72,27 @@ var (
 		MetricTypeCumulativeHistogram,
 	}, "") + `]$`)
 )
+
+// AddGauge to queue for submission
+func (c *Check) AddGauge(metricName string, tags cgm.Tags, value interface{}) {
+	if c.metrics != nil {
+		c.metrics.GaugeWithTags(metricName, tags, value)
+	}
+}
+
+// AddHistSample to queue for submission
+func (c *Check) AddHistSample(metricName string, tags cgm.Tags, value float64) {
+	if c.metrics != nil {
+		c.metrics.TimingWithTags(metricName, tags, value)
+	}
+}
+
+// AddText to queue for submission
+func (c *Check) AddText(metricName string, tags cgm.Tags, value string) {
+	if c.metrics != nil {
+		c.metrics.SetTextWithTags(metricName, tags, value)
+	}
+}
 
 // WriteMetricSample to queue for submission
 func (c *Check) WriteMetricSample(

--- a/internal/circonus/metrics.go
+++ b/internal/circonus/metrics.go
@@ -170,18 +170,21 @@ func (c *Check) QueueMetricSample(
 		return errors.New("invalid metric type (empty)")
 	}
 
-	if len(streamTags)+len(measurementTags) > MaxTags {
+	streamTagList := strings.Split(c.config.DefaultStreamtags, ",")
+	streamTagList = append(streamTagList, streamTags...)
+
+	if len(streamTagList)+len(measurementTags) > MaxTags {
 		c.log.Warn().
 			Str("metric_name", metricName).
-			Strs("stream_tags", streamTags).
+			Strs("stream_tags", streamTagList).
 			Strs("measurement_tags", measurementTags).
-			Int("num_tags", len(streamTags)+len(measurementTags)).
+			Int("num_tags", len(streamTagList)+len(measurementTags)).
 			Int("max_tags", MaxTags).
 			Msg("max metric tags exceeded, discarding")
 		return nil
 	}
 
-	taggedMetricName := c.taggedName(metricName, streamTags, measurementTags)
+	taggedMetricName := c.taggedName(metricName, streamTagList, measurementTags)
 
 	if len(taggedMetricName) > MaxMetricNameLen {
 		c.log.Warn().
@@ -204,7 +207,7 @@ func (c *Check) QueueMetricSample(
 	if _, found := metrics[taggedMetricName]; found {
 		c.log.Warn().
 			Str("metric_name", metricName).
-			Strs("stream_tags", streamTags).
+			Strs("stream_tags", streamTagList).
 			Strs("measurement_tags", measurementTags).
 			Str("tagged_name", taggedMetricName).
 			Msg("already present, overwriting...")

--- a/internal/circonus/metrics.go
+++ b/internal/circonus/metrics.go
@@ -94,6 +94,13 @@ func (c *Check) AddText(metricName string, tags cgm.Tags, value string) {
 	}
 }
 
+// IncrementCounter to queue for submission
+func (c *Check) IncrementCounter(metricName string, tags cgm.Tags) {
+	if c.metrics != nil {
+		c.metrics.IncrementWithTags(metricName, tags)
+	}
+}
+
 // WriteMetricSample to queue for submission
 func (c *Check) WriteMetricSample(
 	metricDest io.Writer,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -48,6 +48,7 @@ type Cluster struct {
 	NodePoolSize           uint   `mapstructure:"node_pool_size" json:"node_pool_size" toml:"node_pool_size" yaml:"node_pool_size"`
 	URL                    string `mapstructure:"api_url" json:"api_url" toml:"api_url" yaml:"api_url"`
 	CAFile                 string `mapstructure:"api_ca_file" json:"api_ca_file" toml:"api_ca_file" yaml:"api_ca_file"`
+	APITimelimit           string `mapstructure:"api_timelimit" json:"api_timelimit" toml:"api_timelimit" yaml:"api_timelimit"`
 }
 
 // LabelFilters defines labels to include and exclude

--- a/internal/config/defaults/defaults.go
+++ b/internal/config/defaults/defaults.go
@@ -78,6 +78,7 @@ const (
 	K8SPodLabelKey            = "" // blank=all
 	K8SPodLabelVal            = "" // blank=all
 	K8SIncludeContainers      = false
+	K8SAPITimelimit           = "10s"
 )
 
 var (

--- a/internal/config/keys/keys.go
+++ b/internal/config/keys/keys.go
@@ -165,6 +165,9 @@ const (
 	// K8SNodePoolSize size of the node collector pool
 	K8SNodePoolSize = "kubernetes.node_pool_size"
 
+	// K8SAPITimelimit amount of time to wait for a complete response from api-server
+	K8SAPITimelimit = "kubernetes.api_timelimit"
+
 	//
 	// Kubernetes clusters (multiple, use either kubernetes or clusters, not both)
 	//

--- a/internal/k8s/api.go
+++ b/internal/k8s/api.go
@@ -16,15 +16,20 @@ import (
 
 func NewAPIClient(tlscfg *tls.Config) (*http.Client, error) {
 
+	// set limit on how long to wait for each individual
+	// request to the api server
+	requestTimelimit := 10 * time.Second
+
 	var client *http.Client
 
 	if tlscfg != nil {
 		client = &http.Client{
+			Timeout: requestTimelimit,
 			Transport: &http.Transport{
 				Proxy: http.ProxyFromEnvironment,
 				DialContext: (&net.Dialer{
-					Timeout:   30 * time.Second,
-					KeepAlive: 30 * time.Second,
+					Timeout:   5 * time.Second,
+					KeepAlive: 3 * time.Second,
 					DualStack: true,
 				}).DialContext,
 				TLSClientConfig:     tlscfg,
@@ -36,11 +41,12 @@ func NewAPIClient(tlscfg *tls.Config) (*http.Client, error) {
 		}
 	} else {
 		client = &http.Client{
+			Timeout: requestTimelimit,
 			Transport: &http.Transport{
 				Proxy: http.ProxyFromEnvironment,
 				DialContext: (&net.Dialer{
-					Timeout:   30 * time.Second,
-					KeepAlive: 30 * time.Second,
+					Timeout:   5 * time.Second,
+					KeepAlive: 3 * time.Second,
 					DualStack: true,
 				}).DialContext,
 				DisableKeepAlives:   false,

--- a/internal/k8s/api.go
+++ b/internal/k8s/api.go
@@ -14,17 +14,16 @@ import (
 	"github.com/pkg/errors"
 )
 
-func NewAPIClient(tlscfg *tls.Config) (*http.Client, error) {
-
-	// set limit on how long to wait for each individual
-	// request to the api server
-	requestTimelimit := 10 * time.Second
+func NewAPIClient(tlscfg *tls.Config, reqTimeout time.Duration) (*http.Client, error) {
+	if reqTimeout == time.Duration(0) {
+		reqTimeout = 10 * time.Second
+	}
 
 	var client *http.Client
 
 	if tlscfg != nil {
 		client = &http.Client{
-			Timeout: requestTimelimit,
+			Timeout: reqTimeout,
 			Transport: &http.Transport{
 				Proxy: http.ProxyFromEnvironment,
 				DialContext: (&net.Dialer{
@@ -41,7 +40,7 @@ func NewAPIClient(tlscfg *tls.Config) (*http.Client, error) {
 		}
 	} else {
 		client = &http.Client{
-			Timeout: requestTimelimit,
+			Timeout: reqTimeout,
 			Transport: &http.Transport{
 				Proxy: http.ProxyFromEnvironment,
 				DialContext: (&net.Dialer{

--- a/internal/ksm/ksm.go
+++ b/internal/ksm/ksm.go
@@ -237,6 +237,10 @@ func (ksm *KSM) metrics(ctx context.Context, tlsConfig *tls.Config, metricURL st
 	start := time.Now()
 	resp, err := client.Do(req)
 	if err != nil {
+		ksm.check.IncrementCounter("collect_api_errors", cgm.Tags{
+			cgm.Tag{Category: "type", Value: "metrics"},
+			cgm.Tag{Category: "source", Value: "api-server"},
+			cgm.Tag{Category: "origin", Value: "kube-state-metrics"}})
 		return err
 	}
 	defer resp.Body.Close()
@@ -288,6 +292,10 @@ func (ksm *KSM) telemetry(ctx context.Context, tlsConfig *tls.Config, telemetryU
 	start := time.Now()
 	resp, err := client.Do(req)
 	if err != nil {
+		ksm.check.IncrementCounter("collect_api_errors", cgm.Tags{
+			cgm.Tag{Category: "type", Value: "telemetry"},
+			cgm.Tag{Category: "source", Value: "api-server"},
+			cgm.Tag{Category: "origin", Value: "kube-state-metrics"}})
 		return err
 	}
 	defer resp.Body.Close()

--- a/internal/ksm/ksm.go
+++ b/internal/ksm/ksm.go
@@ -20,6 +20,7 @@ import (
 	cgm "github.com/circonus-labs/circonus-gometrics/v3"
 	"github.com/circonus-labs/circonus-kubernetes-agent/internal/circonus"
 	"github.com/circonus-labs/circonus-kubernetes-agent/internal/config"
+	"github.com/circonus-labs/circonus-kubernetes-agent/internal/config/defaults"
 	"github.com/circonus-labs/circonus-kubernetes-agent/internal/k8s"
 	"github.com/circonus-labs/circonus-kubernetes-agent/internal/promtext"
 	"github.com/pkg/errors"
@@ -27,10 +28,11 @@ import (
 )
 
 type KSM struct {
-	config  *config.Cluster
-	check   *circonus.Check
-	log     zerolog.Logger
-	running bool
+	config       *config.Cluster
+	check        *circonus.Check
+	log          zerolog.Logger
+	apiTimelimit time.Duration
+	running      bool
 	sync.Mutex
 	ts *time.Time
 }
@@ -53,6 +55,23 @@ func New(cfg *config.Cluster, parentLogger zerolog.Logger, check *circonus.Check
 		config: cfg,
 		check:  check,
 		log:    parentLogger.With().Str("collector", "kube-state-metrics").Logger(),
+	}
+
+	if cfg.APITimelimit != "" {
+		v, err := time.ParseDuration(cfg.APITimelimit)
+		if err != nil {
+			ksm.log.Error().Err(err).Msg("parsing api timelimit, using default")
+		} else {
+			ksm.apiTimelimit = v
+		}
+	}
+
+	if ksm.apiTimelimit == time.Duration(0) {
+		v, err := time.ParseDuration(defaults.K8SAPITimelimit)
+		if err != nil {
+			ksm.log.Fatal().Err(err).Msg("parsing DEFAULT api timelimit")
+		}
+		ksm.apiTimelimit = v
 	}
 
 	return ksm, nil
@@ -159,7 +178,7 @@ func (ksm *KSM) getServiceDefinition(tlsConfig *tls.Config) (*k8s.Service, error
 	q.Set("fieldSelector", "metadata.name=kube-state-metrics")
 	u.RawQuery = q.Encode()
 
-	client, err := k8s.NewAPIClient(tlsConfig)
+	client, err := k8s.NewAPIClient(tlsConfig, ksm.apiTimelimit)
 	if err != nil {
 		return nil, errors.Wrap(err, "service definition cli")
 	}
@@ -204,7 +223,7 @@ func (ksm *KSM) getServiceDefinition(tlsConfig *tls.Config) (*k8s.Service, error
 }
 
 func (ksm *KSM) metrics(ctx context.Context, tlsConfig *tls.Config, metricURL string) error {
-	client, err := k8s.NewAPIClient(tlsConfig)
+	client, err := k8s.NewAPIClient(tlsConfig, ksm.apiTimelimit)
 	if err != nil {
 		return errors.Wrap(err, "/metrics cli")
 	}
@@ -255,7 +274,7 @@ func (ksm *KSM) metrics(ctx context.Context, tlsConfig *tls.Config, metricURL st
 }
 
 func (ksm *KSM) telemetry(ctx context.Context, tlsConfig *tls.Config, telemetryURL string) error {
-	client, err := k8s.NewAPIClient(tlsConfig)
+	client, err := k8s.NewAPIClient(tlsConfig, ksm.apiTimelimit)
 	if err != nil {
 		return errors.Wrap(err, "/telemetry cli")
 	}

--- a/internal/ms/ms.go
+++ b/internal/ms/ms.go
@@ -122,6 +122,10 @@ func (ms *MS) Collect(ctx context.Context, tlsConfig *tls.Config, ts *time.Time)
 	start := time.Now()
 	resp, err := client.Do(req)
 	if err != nil {
+		ms.check.IncrementCounter("collect_api_errors", cgm.Tags{
+			cgm.Tag{Category: "type", Value: "metrics"},
+			cgm.Tag{Category: "source", Value: "api-server"},
+			cgm.Tag{Category: "origin", Value: "metric-server"}})
 		ms.log.Error().Err(err).Str("url", metricsURL).Msg("metrics")
 		ms.Lock()
 		ms.running = false

--- a/internal/nodes/collector/collector.go
+++ b/internal/nodes/collector/collector.go
@@ -425,6 +425,10 @@ func (nc *Collector) summary(parentStreamTags []string, parentMeasurementTags []
 	start := time.Now()
 	resp, err := client.Do(req)
 	if err != nil {
+		nc.check.IncrementCounter("collect_api_errors", cgm.Tags{
+			cgm.Tag{Category: "type", Value: "stats/summary"},
+			cgm.Tag{Category: "source", Value: "api-server"},
+			cgm.Tag{Category: "origin", Value: "kubelet"}})
 		nc.log.Error().Err(err).Str("req_url", reqURL).Msg("fetching summary stats")
 		return
 	}
@@ -735,6 +739,10 @@ func (nc *Collector) nmetrics(parentStreamTags []string, parentMeasurementTags [
 	start := time.Now()
 	resp, err := client.Do(req)
 	if err != nil {
+		nc.check.IncrementCounter("collect_api_errors", cgm.Tags{
+			cgm.Tag{Category: "type", Value: "metrics"},
+			cgm.Tag{Category: "source", Value: "api-server"},
+			cgm.Tag{Category: "origin", Value: "kubelet"}})
 		nc.log.Error().Err(err).Str("url", reqURL).Msg("node metrics")
 		return
 	}
@@ -797,6 +805,9 @@ func (nc *Collector) getPodLabels(ns string, name string) (bool, []string, error
 	start := time.Now()
 	resp, err := client.Do(req)
 	if err != nil {
+		nc.check.IncrementCounter("collect_api_errors", cgm.Tags{
+			cgm.Tag{Category: "type", Value: "pod-labels"},
+			cgm.Tag{Category: "source", Value: "api-server"}})
 		return collect, tags, err
 	}
 	defer resp.Body.Close()

--- a/internal/nodes/nodes.go
+++ b/internal/nodes/nodes.go
@@ -197,6 +197,11 @@ func (n *Nodes) nodeList(tlsConfig *tls.Config) (*k8s.NodeList, error) {
 	start := time.Now()
 	resp, err := client.Do(req)
 	if err != nil {
+		n.check.IncrementCounter("collect_api_errors", cgm.Tags{
+			cgm.Tag{Category: "type", Value: "node-list"},
+			cgm.Tag{Category: "source", Value: "api-server"},
+			cgm.Tag{Category: "units", Value: "milliseconds"},
+		})
 		return nil, err
 	}
 	defer resp.Body.Close()


### PR DESCRIPTION
* add: logging on submit retries and non-200 responses
* add: api request timelimit (default:10s)
* add: `kube_pod_deleted` to metric filters
* add: agent metric
* add: api request error metrics
* add: collection duration, api latency, and metric submission latency histograms
* upd: failure message when cluster(s) can't be initialized resulting in 0 clusters
* fix: ensure default tags used in queued metrics
