### PR TITLE
v0.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v0.5.3
+
+* fix: `async_metrics` (queue/stream)
+* fix: drain streamed metrics in bucket
+* fix: use cluster ctx to honor signals
+
 # v0.5.2
 
 * add: collect submit counters (success,fail,error)

--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -5,28 +5,28 @@
     name: circonus-kubernetes-agent
     labels:
       app.kubernetes.io/name: circonus-kubernetes-agent
-      app.kubernetes.io/version: v0.5.2
+      app.kubernetes.io/version: v0.5.3
   spec:
     selector:
       matchLabels:
         app.kubernetes.io/name: circonus-kubernetes-agent
-        app.kubernetes.io/version: v0.5.2
+        app.kubernetes.io/version: v0.5.3
     replicas: 1
     template:
       metadata:
         name: circonus-kubernetes-agent
         labels:
           app.kubernetes.io/name: circonus-kubernetes-agent
-          app.kubernetes.io/version: v0.5.2
+          app.kubernetes.io/version: v0.5.3
       spec:
         nodeSelector:
           kubernetes.io/os: linux
         serviceAccountName: circonus-kubernetes-agent
         containers:
           - name: circonus-kubernetes-agent
-            image: circonuslabs/circonus-kubernetes-agent:v0.5.2
+            image: circonuslabs/circonus-kubernetes-agent:v0.5.3
             ## for ARM64, remove line above and uncomment line below
-            #image: circonuslabs/circonus-kubernetes-agent-arm64:v0.5.2
+            #image: circonuslabs/circonus-kubernetes-agent-arm64:v0.5.3
             command: ["/circonus-kubernetes-agentd"]
             args: 
               #- --debug

--- a/internal/circonus/check.go
+++ b/internal/circonus/check.go
@@ -258,7 +258,7 @@ func (c *Check) createCheckBundle(client *apiclient.API, cfg *config.Circonus) (
 	checkConfig := &apiclient.CheckBundle{
 		Brokers: []string{cfg.Check.BrokerCID},
 		Config: apiclient.CheckBundleConfig{
-			"asynch_metrics": "false",
+			"asynch_metrics": "true",
 			"secret":         secret,
 		},
 		DisplayName:   cfg.Check.Title,

--- a/internal/circonus/submit.go
+++ b/internal/circonus/submit.go
@@ -43,7 +43,7 @@ const (
 	traceTSFormat        = "20060102_150405.000000000"
 )
 
-func (c *Check) FlushCGM() {
+func (c *Check) FlushCGM(ctx context.Context) {
 	if c.metrics != nil {
 		m := c.metrics.FlushMetrics()
 		// c.log.Info().Interface("metrics", m).Msg("sending metrics")
@@ -52,7 +52,7 @@ func (c *Check) FlushCGM() {
 			c.log.Warn().Err(err).Msg("encoding metrics")
 			return
 		}
-		if err := c.SubmitStream(context.Background(), bytes.NewReader(data), c.log); err != nil {
+		if err := c.SubmitStream(ctx, bytes.NewReader(data), c.log); err != nil {
 			c.log.Error().Err(err).Msg("submitting cgm metrics")
 		}
 	}

--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -255,7 +255,7 @@ func (c *Cluster) Start(ctx context.Context) error {
 					c.check.AddGauge("collect_interval", streamTags, uint64(c.interval.Milliseconds()))
 				}
 
-				c.check.FlushCGM()
+				c.check.FlushCGM(ctx)
 
 				c.logger.Info().
 					Interface("metrics_sent", cstats).

--- a/internal/promtext/promtext.go
+++ b/internal/promtext/promtext.go
@@ -326,6 +326,13 @@ func StreamMetrics(
 			}
 		}
 	}
+	// send any remaining metrics
+	if buf.Len() > 0 {
+		if err := targetCheck.SubmitStream(ctx, &buf, logger); err != nil {
+			logger.Warn().Err(err).Msg("submitting metrics")
+		}
+
+	}
 
 	return nil
 }


### PR DESCRIPTION
* fix: `async_metrics` (queue/stream)
* fix: drain streamed metrics in bucket
* fix: use cluster ctx to honor signals
