### PR TITLE
v0.5.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# v0.5.5
+
+* upd: increase metric bucket size to 1000
+* fix: typo in metric name
+* upd: use `resultLogger` to identify source of submission errors/retries
+* add: set `collect_submit_retries` to 0 at start of each collection run
+
 # v0.5.4
 
 * add: liveness probe support `/health`

--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -5,28 +5,28 @@
     name: circonus-kubernetes-agent
     labels:
       app.kubernetes.io/name: circonus-kubernetes-agent
-      app.kubernetes.io/version: v0.5.4
+      app.kubernetes.io/version: v0.5.5
   spec:
     selector:
       matchLabels:
         app.kubernetes.io/name: circonus-kubernetes-agent
-        app.kubernetes.io/version: v0.5.4
+        app.kubernetes.io/version: v0.5.5
     replicas: 1
     template:
       metadata:
         name: circonus-kubernetes-agent
         labels:
           app.kubernetes.io/name: circonus-kubernetes-agent
-          app.kubernetes.io/version: v0.5.4
+          app.kubernetes.io/version: v0.5.5
       spec:
         nodeSelector:
           kubernetes.io/os: linux
         serviceAccountName: circonus-kubernetes-agent
         containers:
           - name: circonus-kubernetes-agent
-            image: circonuslabs/circonus-kubernetes-agent:v0.5.4
+            image: circonuslabs/circonus-kubernetes-agent:v0.5.5
             ## for ARM64, remove line above and uncomment line below
-            #image: circonuslabs/circonus-kubernetes-agent-arm64:v0.5.4
+            #image: circonuslabs/circonus-kubernetes-agent-arm64:v0.5.5
             command: ["/circonus-kubernetes-agentd"]
             args: 
               #- --debug

--- a/internal/circonus/metrics.go
+++ b/internal/circonus/metrics.go
@@ -101,6 +101,13 @@ func (c *Check) IncrementCounter(metricName string, tags cgm.Tags) {
 	}
 }
 
+// SetCounter to queue for submission
+func (c *Check) SetCounter(metricName string, tags cgm.Tags, value uint64) {
+	if c.metrics != nil {
+		c.metrics.SetWithTags(metricName, tags, value)
+	}
+}
+
 // WriteMetricSample to queue for submission
 func (c *Check) WriteMetricSample(
 	metricDest io.Writer,

--- a/internal/circonus/submit.go
+++ b/internal/circonus/submit.go
@@ -13,7 +13,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
 	"net"
 	"net/http"
 	"net/http/httputil"
@@ -104,186 +103,207 @@ func (c *Check) SubmitStream(ctx context.Context, metrics io.Reader, resultLogge
 		return errors.New("no submission url and not in dry-run mode")
 	}
 
-	var client *http.Client
+	go func() {
+		var client *http.Client
 
-	if c.brokerTLSConfig != nil {
-		client = &http.Client{
-			Transport: &http.Transport{
-				Proxy: http.ProxyFromEnvironment,
-				DialContext: (&net.Dialer{
-					Timeout:   10 * time.Second,
-					KeepAlive: 3 * time.Second,
-					DualStack: true,
-				}).DialContext,
-				TLSClientConfig:     c.brokerTLSConfig,
-				TLSHandshakeTimeout: 10 * time.Second,
-				DisableKeepAlives:   false,
-				MaxIdleConnsPerHost: 2,
-				DisableCompression:  false,
-			},
-		}
-	} else {
-		client = &http.Client{
-			Transport: &http.Transport{
-				Proxy: http.ProxyFromEnvironment,
-				DialContext: (&net.Dialer{
-					Timeout:   10 * time.Second,
-					KeepAlive: 3 * time.Second,
-					DualStack: true,
-				}).DialContext,
-				DisableKeepAlives:   false,
-				MaxIdleConnsPerHost: 2,
-				DisableCompression:  false,
-			},
-		}
-	}
-
-	submitUUID, err := uuid.NewRandom()
-	if err != nil {
-		return errors.Wrap(err, "creating new submit ID")
-	}
-
-	rawData, err := ioutil.ReadAll(metrics)
-	if err != nil {
-		return errors.Wrap(err, "reading metric data")
-	}
-
-	payloadIsCompressed := false
-
-	var subData *bytes.Buffer
-	if c.UseCompression() && len(rawData) > compressionThreshold {
-		subData = bytes.NewBuffer([]byte{})
-		zw := gzip.NewWriter(subData)
-		n, err := zw.Write(rawData)
-		if err != nil {
-			return errors.Wrap(err, "compressing metrics")
-		}
-		if n != len(rawData) {
-			return errors.Errorf("write length mismatch data length %d != written length %d", len(rawData), n)
-		}
-		if err := zw.Close(); err != nil {
-			return errors.Wrap(err, "closing gzip writer")
-		}
-		payloadIsCompressed = true
-	} else {
-		subData = bytes.NewBuffer(rawData)
-	}
-
-	if dumpDir := c.config.TraceSubmits; dumpDir != "" {
-		fn := path.Join(dumpDir, time.Now().UTC().Format(traceTSFormat)+"_"+submitUUID.String()+".json")
-		if payloadIsCompressed {
-			fn += ".gz"
-		}
-		fh, err := os.Create(fn)
-		if err != nil {
-			c.log.Error().Err(err).Str("file", fn).Msg("skipping submit trace")
+		if c.brokerTLSConfig != nil {
+			client = &http.Client{
+				Transport: &http.Transport{
+					Proxy: http.ProxyFromEnvironment,
+					DialContext: (&net.Dialer{
+						Timeout:   10 * time.Second,
+						KeepAlive: 3 * time.Second,
+						DualStack: true,
+					}).DialContext,
+					TLSClientConfig:     c.brokerTLSConfig,
+					TLSHandshakeTimeout: 10 * time.Second,
+					DisableKeepAlives:   false,
+					MaxIdleConnsPerHost: 2,
+					DisableCompression:  false,
+				},
+			}
 		} else {
-			if _, err := fh.Write(subData.Bytes()); err != nil {
-				c.log.Error().Err(err).Msg("writing metric trace")
-			}
-			if err := fh.Close(); err != nil {
-				c.log.Error().Err(err).Str("file", fn).Msg("closing metric trace")
+			client = &http.Client{
+				Transport: &http.Transport{
+					Proxy: http.ProxyFromEnvironment,
+					DialContext: (&net.Dialer{
+						Timeout:   10 * time.Second,
+						KeepAlive: 3 * time.Second,
+						DualStack: true,
+					}).DialContext,
+					DisableKeepAlives:   false,
+					MaxIdleConnsPerHost: 2,
+					DisableCompression:  false,
+				},
 			}
 		}
-	}
 
-	dataLen := subData.Len()
-
-	reqStart := time.Now()
-
-	req, err := retryablehttp.NewRequest("PUT", c.submissionURL, subData)
-	if err != nil {
-		return err
-	}
-	req = req.WithContext(ctx)
-	req.Header.Set("User-Agent", release.NAME+"/"+release.VERSION)
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Accept", "application/json")
-	req.Header.Set("Connection", "close")
-	req.Header.Set("Content-Length", strconv.Itoa(dataLen))
-	if payloadIsCompressed {
-		req.Header.Set("Content-Encoding", "gzip")
-	}
-
-	if c.DebugSubmissions() {
-		dump, err := httputil.DumpRequestOut(req.Request, !payloadIsCompressed)
+		submitUUID, err := uuid.NewRandom()
 		if err != nil {
-			log.Fatal(err)
+			resultLogger.Error().Err(err).Msg("creating new submit ID")
+			return
+			// return errors.Wrap(err, "creating new submit ID")
 		}
 
-		fmt.Println(string(dump))
-	}
-
-	retryClient := retryablehttp.NewClient()
-	retryClient.HTTPClient = client
-	retryClient.Logger = logshim{logh: c.log.With().Str("pkg", "retryablehttp").Logger()}
-	retryClient.RetryWaitMin = 50 * time.Millisecond
-	retryClient.RetryWaitMax = 2 * time.Second
-	retryClient.RetryMax = 10
-	retryClient.RequestLogHook = func(l retryablehttp.Logger, r *http.Request, attempt int) {
-		if attempt > 0 {
-			c.metrics.IncrementWithTags("collect_submit_reties", cgm.Tags{cgm.Tag{Category: "source", Value: release.NAME}})
-			reqStart = time.Now()
-			resultLogger.Warn().Str("url", r.URL.String()).Int("attempt", attempt).Msg("retrying...")
+		rawData, err := ioutil.ReadAll(metrics)
+		if err != nil {
+			resultLogger.Error().Err(err).Msg("reading metric data")
+			return
+			// return errors.Wrap(err, "reading metric data")
 		}
-	}
-	retryClient.ResponseLogHook = func(l retryablehttp.Logger, r *http.Response) {
-		c.AddHistSample("collect_latency", cgm.Tags{
-			cgm.Tag{Category: "type", Value: "submit"},
-			cgm.Tag{Category: "source", Value: release.NAME},
-			cgm.Tag{Category: "units", Value: "milliseconds"},
-		}, float64(time.Since(reqStart).Milliseconds()))
-		if r.StatusCode != http.StatusOK {
-			c.metrics.IncrementWithTags("collect_submit_errors", cgm.Tags{
-				cgm.Tag{Category: "code", Value: fmt.Sprintf("%d", r.StatusCode)},
+
+		payloadIsCompressed := false
+
+		var subData *bytes.Buffer
+		if c.UseCompression() && len(rawData) > compressionThreshold {
+			subData = bytes.NewBuffer([]byte{})
+			zw := gzip.NewWriter(subData)
+			n, err := zw.Write(rawData)
+			if err != nil {
+				resultLogger.Error().Err(err).Msg("compressing metrics")
+				return
+				// return errors.Wrap(err, "compressing metrics")
+			}
+			if n != len(rawData) {
+				resultLogger.Error().Err(err).Int("data_len", len(rawData)).Int("written", n).Msg("gzip write length mismatch")
+				return
+				//return errors.Errorf("write length mismatch data length %d != written length %d", len(rawData), n)
+			}
+			if err := zw.Close(); err != nil {
+				resultLogger.Error().Err(err).Msg("closing gzip writer")
+				return
+				// return errors.Wrap(err, "closing gzip writer")
+			}
+			payloadIsCompressed = true
+		} else {
+			subData = bytes.NewBuffer(rawData)
+		}
+
+		if dumpDir := c.config.TraceSubmits; dumpDir != "" {
+			fn := path.Join(dumpDir, time.Now().UTC().Format(traceTSFormat)+"_"+submitUUID.String()+".json")
+			if payloadIsCompressed {
+				fn += ".gz"
+			}
+			fh, err := os.Create(fn)
+			if err != nil {
+				c.log.Error().Err(err).Str("file", fn).Msg("skipping submit trace")
+			} else {
+				if _, err := fh.Write(subData.Bytes()); err != nil {
+					resultLogger.Error().Err(err).Msg("writing metric trace")
+				}
+				if err := fh.Close(); err != nil {
+					resultLogger.Error().Err(err).Str("file", fn).Msg("closing metric trace")
+				}
+			}
+		}
+
+		dataLen := subData.Len()
+
+		reqStart := time.Now()
+
+		req, err := retryablehttp.NewRequest("PUT", c.submissionURL, subData)
+		if err != nil {
+			resultLogger.Error().Err(err).Msg("creating submission request")
+			return
+			// return err
+		}
+		req = req.WithContext(ctx)
+		req.Header.Set("User-Agent", release.NAME+"/"+release.VERSION)
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Accept", "application/json")
+		req.Header.Set("Connection", "close")
+		req.Header.Set("Content-Length", strconv.Itoa(dataLen))
+		if payloadIsCompressed {
+			req.Header.Set("Content-Encoding", "gzip")
+		}
+
+		if c.DebugSubmissions() {
+			dump, err := httputil.DumpRequestOut(req.Request, !payloadIsCompressed)
+			if err != nil {
+				resultLogger.Error().Err(err).Msg("dumping request")
+				return
+			}
+
+			fmt.Println(string(dump))
+		}
+
+		retryClient := retryablehttp.NewClient()
+		retryClient.HTTPClient = client
+		retryClient.Logger = logshim{logh: c.log.With().Str("pkg", "retryablehttp").Logger()}
+		retryClient.RetryWaitMin = 50 * time.Millisecond
+		retryClient.RetryWaitMax = 2 * time.Second
+		retryClient.RetryMax = 10
+		retryClient.RequestLogHook = func(l retryablehttp.Logger, r *http.Request, attempt int) {
+			if attempt > 0 {
+				c.metrics.IncrementWithTags("collect_submit_reties", cgm.Tags{cgm.Tag{Category: "source", Value: release.NAME}})
+				reqStart = time.Now()
+				resultLogger.Warn().Str("url", r.URL.String()).Int("attempt", attempt).Msg("retrying...")
+			}
+		}
+		retryClient.ResponseLogHook = func(l retryablehttp.Logger, r *http.Response) {
+			c.AddHistSample("collect_latency", cgm.Tags{
+				cgm.Tag{Category: "type", Value: "submit"},
+				cgm.Tag{Category: "source", Value: release.NAME},
+				cgm.Tag{Category: "units", Value: "milliseconds"},
+			}, float64(time.Since(reqStart).Milliseconds()))
+			if r.StatusCode != http.StatusOK {
+				c.metrics.IncrementWithTags("collect_submit_errors", cgm.Tags{
+					cgm.Tag{Category: "code", Value: fmt.Sprintf("%d", r.StatusCode)},
+					cgm.Tag{Category: "source", Value: release.NAME},
+				})
+				resultLogger.Warn().Str("url", r.Request.URL.String()).Str("status", r.Status).Msg("non-200 response...")
+			}
+		}
+
+		defer retryClient.HTTPClient.CloseIdleConnections()
+
+		resp, err := retryClient.Do(req)
+		if err != nil {
+			resultLogger.Error().Err(err).Msg("making request")
+			// return err
+		}
+
+		body, err := ioutil.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		if err != nil {
+			resultLogger.Error().Err(err).Msg("reading body")
+			return
+			// return err
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			c.metrics.IncrementWithTags("collect_submit_fails", cgm.Tags{
+				cgm.Tag{Category: "code", Value: fmt.Sprintf("%d", resp.StatusCode)},
 				cgm.Tag{Category: "source", Value: release.NAME},
 			})
-			resultLogger.Warn().Str("url", r.Request.URL.String()).Str("status", r.Status).Msg("non-200 response...")
+			resultLogger.Error().Str("url", c.submissionURL).Str("status", resp.Status).Str("body", string(body)).Msg("submitting telemetry")
+			return
+			// return errors.Errorf("submitting metrics (%s %s)", c.submissionURL, resp.Status)
 		}
-	}
 
-	defer retryClient.HTTPClient.CloseIdleConnections()
+		c.metrics.IncrementWithTags("collect_submits", cgm.Tags{cgm.Tag{Category: "source", Value: release.NAME}})
 
-	resp, err := retryClient.Do(req)
-	if err != nil {
-		return err
-	}
+		var result TrapResult
+		if err := json.Unmarshal(body, &result); err != nil {
+			resultLogger.Error().Err(err).Str("body", string(body)).Msg("parsing response")
+			return
+			// return errors.Wrapf(err, "parsing response (%s)", string(body))
+		}
 
-	body, err := ioutil.ReadAll(resp.Body)
-	_ = resp.Body.Close()
-	if err != nil {
-		return err
-	}
+		result.CheckUUID = c.checkUUID
+		result.SubmitUUID = submitUUID
 
-	if resp.StatusCode != http.StatusOK {
-		c.metrics.IncrementWithTags("collect_submit_fails", cgm.Tags{
-			cgm.Tag{Category: "code", Value: fmt.Sprintf("%d", resp.StatusCode)},
-			cgm.Tag{Category: "source", Value: release.NAME},
-		})
-		resultLogger.Error().Str("url", c.submissionURL).Str("status", resp.Status).Str("body", string(body)).Msg("submitting telemetry")
-		return errors.Errorf("submitting metrics (%s %s)", c.submissionURL, resp.Status)
-	}
+		resultLogger.Debug().
+			Str("duration", time.Since(start).String()).
+			Interface("result", result).
+			Str("bytes_sent", bytefmt.ByteSize(uint64(dataLen))).
+			Msg("submitted")
 
-	c.metrics.IncrementWithTags("collect_submits", cgm.Tags{cgm.Tag{Category: "source", Value: release.NAME}})
-
-	var result TrapResult
-	if err := json.Unmarshal(body, &result); err != nil {
-		return errors.Wrapf(err, "parsing response (%s)", string(body))
-	}
-
-	result.CheckUUID = c.checkUUID
-	result.SubmitUUID = submitUUID
-
-	resultLogger.Debug().
-		Str("duration", time.Since(start).String()).
-		Interface("result", result).
-		Str("bytes_sent", bytefmt.ByteSize(uint64(dataLen))).
-		Msg("submitted")
-
-	c.statsmu.Lock()
-	c.stats.Metrics += result.Stats
-	c.stats.SentBytes += uint64(dataLen)
-	c.statsmu.Unlock()
+		c.statsmu.Lock()
+		c.stats.Metrics += result.Stats
+		c.stats.SentBytes += uint64(dataLen)
+		c.statsmu.Unlock()
+	}()
 
 	return nil
 }

--- a/internal/circonus/submit.go
+++ b/internal/circonus/submit.go
@@ -103,207 +103,196 @@ func (c *Check) SubmitStream(ctx context.Context, metrics io.Reader, resultLogge
 		return errors.New("no submission url and not in dry-run mode")
 	}
 
-	go func() {
-		var client *http.Client
+	var client *http.Client
 
-		if c.brokerTLSConfig != nil {
-			client = &http.Client{
-				Transport: &http.Transport{
-					Proxy: http.ProxyFromEnvironment,
-					DialContext: (&net.Dialer{
-						Timeout:   10 * time.Second,
-						KeepAlive: 3 * time.Second,
-						DualStack: true,
-					}).DialContext,
-					TLSClientConfig:     c.brokerTLSConfig,
-					TLSHandshakeTimeout: 10 * time.Second,
-					DisableKeepAlives:   false,
-					MaxIdleConnsPerHost: 2,
-					DisableCompression:  false,
-				},
-			}
-		} else {
-			client = &http.Client{
-				Transport: &http.Transport{
-					Proxy: http.ProxyFromEnvironment,
-					DialContext: (&net.Dialer{
-						Timeout:   10 * time.Second,
-						KeepAlive: 3 * time.Second,
-						DualStack: true,
-					}).DialContext,
-					DisableKeepAlives:   false,
-					MaxIdleConnsPerHost: 2,
-					DisableCompression:  false,
-				},
-			}
+	if c.brokerTLSConfig != nil {
+		client = &http.Client{
+			Transport: &http.Transport{
+				Proxy: http.ProxyFromEnvironment,
+				DialContext: (&net.Dialer{
+					Timeout:   10 * time.Second,
+					KeepAlive: 3 * time.Second,
+					DualStack: true,
+				}).DialContext,
+				TLSClientConfig:     c.brokerTLSConfig,
+				TLSHandshakeTimeout: 10 * time.Second,
+				DisableKeepAlives:   false,
+				MaxIdleConnsPerHost: 2,
+				DisableCompression:  false,
+			},
 		}
+	} else {
+		client = &http.Client{
+			Transport: &http.Transport{
+				Proxy: http.ProxyFromEnvironment,
+				DialContext: (&net.Dialer{
+					Timeout:   10 * time.Second,
+					KeepAlive: 3 * time.Second,
+					DualStack: true,
+				}).DialContext,
+				DisableKeepAlives:   false,
+				MaxIdleConnsPerHost: 2,
+				DisableCompression:  false,
+			},
+		}
+	}
 
-		submitUUID, err := uuid.NewRandom()
+	submitUUID, err := uuid.NewRandom()
+	if err != nil {
+		resultLogger.Error().Err(err).Msg("creating new submit ID")
+		return errors.Wrap(err, "creating new submit ID")
+	}
+
+	rawData, err := ioutil.ReadAll(metrics)
+	if err != nil {
+		resultLogger.Error().Err(err).Msg("reading metric data")
+		return errors.Wrap(err, "reading metric data")
+	}
+
+	payloadIsCompressed := false
+
+	var subData *bytes.Buffer
+	if c.UseCompression() && len(rawData) > compressionThreshold {
+		subData = bytes.NewBuffer([]byte{})
+		zw := gzip.NewWriter(subData)
+		n, err := zw.Write(rawData)
 		if err != nil {
-			resultLogger.Error().Err(err).Msg("creating new submit ID")
-			return
-			// return errors.Wrap(err, "creating new submit ID")
+			resultLogger.Error().Err(err).Msg("compressing metrics")
+			return errors.Wrap(err, "compressing metrics")
 		}
-
-		rawData, err := ioutil.ReadAll(metrics)
-		if err != nil {
-			resultLogger.Error().Err(err).Msg("reading metric data")
-			return
-			// return errors.Wrap(err, "reading metric data")
+		if n != len(rawData) {
+			resultLogger.Error().Err(err).Int("data_len", len(rawData)).Int("written", n).Msg("gzip write length mismatch")
+			return errors.Errorf("write length mismatch data length %d != written length %d", len(rawData), n)
 		}
-
-		payloadIsCompressed := false
-
-		var subData *bytes.Buffer
-		if c.UseCompression() && len(rawData) > compressionThreshold {
-			subData = bytes.NewBuffer([]byte{})
-			zw := gzip.NewWriter(subData)
-			n, err := zw.Write(rawData)
-			if err != nil {
-				resultLogger.Error().Err(err).Msg("compressing metrics")
-				return
-				// return errors.Wrap(err, "compressing metrics")
-			}
-			if n != len(rawData) {
-				resultLogger.Error().Err(err).Int("data_len", len(rawData)).Int("written", n).Msg("gzip write length mismatch")
-				return
-				//return errors.Errorf("write length mismatch data length %d != written length %d", len(rawData), n)
-			}
-			if err := zw.Close(); err != nil {
-				resultLogger.Error().Err(err).Msg("closing gzip writer")
-				return
-				// return errors.Wrap(err, "closing gzip writer")
-			}
-			payloadIsCompressed = true
-		} else {
-			subData = bytes.NewBuffer(rawData)
+		if err := zw.Close(); err != nil {
+			resultLogger.Error().Err(err).Msg("closing gzip writer")
+			return errors.Wrap(err, "closing gzip writer")
 		}
+		payloadIsCompressed = true
+	} else {
+		subData = bytes.NewBuffer(rawData)
+	}
 
-		if dumpDir := c.config.TraceSubmits; dumpDir != "" {
-			fn := path.Join(dumpDir, time.Now().UTC().Format(traceTSFormat)+"_"+submitUUID.String()+".json")
-			if payloadIsCompressed {
-				fn += ".gz"
-			}
-			fh, err := os.Create(fn)
-			if err != nil {
-				c.log.Error().Err(err).Str("file", fn).Msg("skipping submit trace")
-			} else {
-				if _, err := fh.Write(subData.Bytes()); err != nil {
-					resultLogger.Error().Err(err).Msg("writing metric trace")
-				}
-				if err := fh.Close(); err != nil {
-					resultLogger.Error().Err(err).Str("file", fn).Msg("closing metric trace")
-				}
-			}
-		}
-
-		dataLen := subData.Len()
-
-		reqStart := time.Now()
-
-		req, err := retryablehttp.NewRequest("PUT", c.submissionURL, subData)
-		if err != nil {
-			resultLogger.Error().Err(err).Msg("creating submission request")
-			return
-			// return err
-		}
-		req = req.WithContext(ctx)
-		req.Header.Set("User-Agent", release.NAME+"/"+release.VERSION)
-		req.Header.Set("Content-Type", "application/json")
-		req.Header.Set("Accept", "application/json")
-		req.Header.Set("Connection", "close")
-		req.Header.Set("Content-Length", strconv.Itoa(dataLen))
+	if dumpDir := c.config.TraceSubmits; dumpDir != "" {
+		fn := path.Join(dumpDir, time.Now().UTC().Format(traceTSFormat)+"_"+submitUUID.String()+".json")
 		if payloadIsCompressed {
-			req.Header.Set("Content-Encoding", "gzip")
+			fn += ".gz"
 		}
-
-		if c.DebugSubmissions() {
-			dump, err := httputil.DumpRequestOut(req.Request, !payloadIsCompressed)
-			if err != nil {
-				resultLogger.Error().Err(err).Msg("dumping request")
-				return
-			}
-
-			fmt.Println(string(dump))
-		}
-
-		retryClient := retryablehttp.NewClient()
-		retryClient.HTTPClient = client
-		retryClient.Logger = logshim{logh: c.log.With().Str("pkg", "retryablehttp").Logger()}
-		retryClient.RetryWaitMin = 50 * time.Millisecond
-		retryClient.RetryWaitMax = 2 * time.Second
-		retryClient.RetryMax = 10
-		retryClient.RequestLogHook = func(l retryablehttp.Logger, r *http.Request, attempt int) {
-			if attempt > 0 {
-				c.metrics.IncrementWithTags("collect_submit_reties", cgm.Tags{cgm.Tag{Category: "source", Value: release.NAME}})
-				reqStart = time.Now()
-				resultLogger.Warn().Str("url", r.URL.String()).Int("attempt", attempt).Msg("retrying...")
-			}
-		}
-		retryClient.ResponseLogHook = func(l retryablehttp.Logger, r *http.Response) {
-			c.AddHistSample("collect_latency", cgm.Tags{
-				cgm.Tag{Category: "type", Value: "submit"},
-				cgm.Tag{Category: "source", Value: release.NAME},
-				cgm.Tag{Category: "units", Value: "milliseconds"},
-			}, float64(time.Since(reqStart).Milliseconds()))
-			if r.StatusCode != http.StatusOK {
-				c.metrics.IncrementWithTags("collect_submit_errors", cgm.Tags{
-					cgm.Tag{Category: "code", Value: fmt.Sprintf("%d", r.StatusCode)},
-					cgm.Tag{Category: "source", Value: release.NAME},
-				})
-				resultLogger.Warn().Str("url", r.Request.URL.String()).Str("status", r.Status).Msg("non-200 response...")
-			}
-		}
-
-		defer retryClient.HTTPClient.CloseIdleConnections()
-
-		resp, err := retryClient.Do(req)
+		fh, err := os.Create(fn)
 		if err != nil {
-			resultLogger.Error().Err(err).Msg("making request")
-			// return err
+			c.log.Error().Err(err).Str("file", fn).Msg("skipping submit trace")
+		} else {
+			if _, err := fh.Write(subData.Bytes()); err != nil {
+				resultLogger.Error().Err(err).Msg("writing metric trace")
+			}
+			if err := fh.Close(); err != nil {
+				resultLogger.Error().Err(err).Str("file", fn).Msg("closing metric trace")
+			}
 		}
+	}
 
-		body, err := ioutil.ReadAll(resp.Body)
-		_ = resp.Body.Close()
+	dataLen := subData.Len()
+
+	reqStart := time.Now()
+
+	req, err := retryablehttp.NewRequest("PUT", c.submissionURL, subData)
+	if err != nil {
+		resultLogger.Error().Err(err).Msg("creating submission request")
+		return err
+	}
+	req = req.WithContext(ctx)
+	req.Header.Set("User-Agent", release.NAME+"/"+release.VERSION)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Connection", "close")
+	req.Header.Set("Content-Length", strconv.Itoa(dataLen))
+	if payloadIsCompressed {
+		req.Header.Set("Content-Encoding", "gzip")
+	}
+
+	if c.DebugSubmissions() {
+		dump, err := httputil.DumpRequestOut(req.Request, !payloadIsCompressed)
 		if err != nil {
-			resultLogger.Error().Err(err).Msg("reading body")
-			return
-			// return err
+			resultLogger.Error().Err(err).Msg("dumping request")
+			return err
 		}
 
-		if resp.StatusCode != http.StatusOK {
-			c.metrics.IncrementWithTags("collect_submit_fails", cgm.Tags{
-				cgm.Tag{Category: "code", Value: fmt.Sprintf("%d", resp.StatusCode)},
+		fmt.Println(string(dump))
+	}
+
+	retryClient := retryablehttp.NewClient()
+	retryClient.HTTPClient = client
+	retryClient.Logger = logshim{logh: c.log.With().Str("pkg", "retryablehttp").Logger()}
+	retryClient.RetryWaitMin = 50 * time.Millisecond
+	retryClient.RetryWaitMax = 2 * time.Second
+	retryClient.RetryMax = 10
+	retryClient.RequestLogHook = func(l retryablehttp.Logger, r *http.Request, attempt int) {
+		if attempt > 0 {
+			c.metrics.IncrementWithTags("collect_submit_reties", cgm.Tags{cgm.Tag{Category: "source", Value: release.NAME}})
+			reqStart = time.Now()
+			resultLogger.Warn().Str("url", r.URL.String()).Int("attempt", attempt).Msg("retrying...")
+		}
+	}
+	retryClient.ResponseLogHook = func(l retryablehttp.Logger, r *http.Response) {
+		c.AddHistSample("collect_latency", cgm.Tags{
+			cgm.Tag{Category: "type", Value: "submit"},
+			cgm.Tag{Category: "source", Value: release.NAME},
+			cgm.Tag{Category: "units", Value: "milliseconds"},
+		}, float64(time.Since(reqStart).Milliseconds()))
+		if r.StatusCode != http.StatusOK {
+			c.metrics.IncrementWithTags("collect_submit_errors", cgm.Tags{
+				cgm.Tag{Category: "code", Value: fmt.Sprintf("%d", r.StatusCode)},
 				cgm.Tag{Category: "source", Value: release.NAME},
 			})
-			resultLogger.Error().Str("url", c.submissionURL).Str("status", resp.Status).Str("body", string(body)).Msg("submitting telemetry")
-			return
-			// return errors.Errorf("submitting metrics (%s %s)", c.submissionURL, resp.Status)
+			resultLogger.Warn().Str("url", r.Request.URL.String()).Str("status", r.Status).Msg("non-200 response...")
 		}
+	}
 
-		c.metrics.IncrementWithTags("collect_submits", cgm.Tags{cgm.Tag{Category: "source", Value: release.NAME}})
+	defer retryClient.HTTPClient.CloseIdleConnections()
 
-		var result TrapResult
-		if err := json.Unmarshal(body, &result); err != nil {
-			resultLogger.Error().Err(err).Str("body", string(body)).Msg("parsing response")
-			return
-			// return errors.Wrapf(err, "parsing response (%s)", string(body))
-		}
+	resp, err := retryClient.Do(req)
+	if err != nil {
+		resultLogger.Error().Err(err).Msg("making request")
+		return err
+	}
 
-		result.CheckUUID = c.checkUUID
-		result.SubmitUUID = submitUUID
+	body, err := ioutil.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if err != nil {
+		resultLogger.Error().Err(err).Msg("reading body")
+		return err
+	}
 
-		resultLogger.Debug().
-			Str("duration", time.Since(start).String()).
-			Interface("result", result).
-			Str("bytes_sent", bytefmt.ByteSize(uint64(dataLen))).
-			Msg("submitted")
+	if resp.StatusCode != http.StatusOK {
+		c.metrics.IncrementWithTags("collect_submit_fails", cgm.Tags{
+			cgm.Tag{Category: "code", Value: fmt.Sprintf("%d", resp.StatusCode)},
+			cgm.Tag{Category: "source", Value: release.NAME},
+		})
+		resultLogger.Error().Str("url", c.submissionURL).Str("status", resp.Status).Str("body", string(body)).Msg("submitting telemetry")
+		return errors.Errorf("submitting metrics (%s %s)", c.submissionURL, resp.Status)
+	}
 
-		c.statsmu.Lock()
-		c.stats.Metrics += result.Stats
-		c.stats.SentBytes += uint64(dataLen)
-		c.statsmu.Unlock()
-	}()
+	c.metrics.IncrementWithTags("collect_submits", cgm.Tags{cgm.Tag{Category: "source", Value: release.NAME}})
+
+	var result TrapResult
+	if err := json.Unmarshal(body, &result); err != nil {
+		resultLogger.Error().Err(err).Str("body", string(body)).Msg("parsing response")
+		return errors.Wrapf(err, "parsing response (%s)", string(body))
+	}
+
+	result.CheckUUID = c.checkUUID
+	result.SubmitUUID = submitUUID
+
+	resultLogger.Debug().
+		Str("duration", time.Since(start).String()).
+		Interface("result", result).
+		Str("bytes_sent", bytefmt.ByteSize(uint64(dataLen))).
+		Msg("submitted")
+
+	c.statsmu.Lock()
+	c.stats.Metrics += result.Stats
+	c.stats.SentBytes += uint64(dataLen)
+	c.statsmu.Unlock()
 
 	return nil
 }

--- a/internal/circonus/submit.go
+++ b/internal/circonus/submit.go
@@ -228,7 +228,7 @@ func (c *Check) SubmitStream(ctx context.Context, metrics io.Reader, resultLogge
 	retryClient.RetryMax = 10
 	retryClient.RequestLogHook = func(l retryablehttp.Logger, r *http.Request, attempt int) {
 		if attempt > 0 {
-			c.metrics.IncrementWithTags("collect_submit_reties", cgm.Tags{cgm.Tag{Category: "source", Value: release.NAME}})
+			c.metrics.IncrementWithTags("collect_submit_retries", cgm.Tags{cgm.Tag{Category: "source", Value: release.NAME}})
 			reqStart = time.Now()
 			resultLogger.Warn().Str("url", r.URL.String()).Int("attempt", attempt).Msg("retrying...")
 		}

--- a/internal/circonus/submit.go
+++ b/internal/circonus/submit.go
@@ -224,7 +224,7 @@ func (c *Check) SubmitStream(ctx context.Context, metrics io.Reader, resultLogge
 		if attempt > 0 {
 			c.metrics.IncrementWithTags("collect_submit_reties", cgm.Tags{cgm.Tag{Category: "source", Value: release.NAME}})
 			reqStart = time.Now()
-			c.log.Warn().Str("url", r.URL.String()).Int("attempt", attempt).Msg("retrying...")
+			resultLogger.Warn().Str("url", r.URL.String()).Int("attempt", attempt).Msg("retrying...")
 		}
 	}
 	retryClient.ResponseLogHook = func(l retryablehttp.Logger, r *http.Response) {
@@ -238,7 +238,7 @@ func (c *Check) SubmitStream(ctx context.Context, metrics io.Reader, resultLogge
 				cgm.Tag{Category: "code", Value: fmt.Sprintf("%d", r.StatusCode)},
 				cgm.Tag{Category: "source", Value: release.NAME},
 			})
-			c.log.Warn().Str("url", r.Request.URL.String()).Str("status", r.Status).Msg("non-200 response...")
+			resultLogger.Warn().Str("url", r.Request.URL.String()).Str("status", r.Status).Msg("non-200 response...")
 		}
 	}
 
@@ -260,7 +260,7 @@ func (c *Check) SubmitStream(ctx context.Context, metrics io.Reader, resultLogge
 			cgm.Tag{Category: "code", Value: fmt.Sprintf("%d", resp.StatusCode)},
 			cgm.Tag{Category: "source", Value: release.NAME},
 		})
-		c.log.Error().Str("url", c.submissionURL).Str("status", resp.Status).Str("body", string(body)).Msg("submitting telemetry")
+		resultLogger.Error().Str("url", c.submissionURL).Str("status", resp.Status).Str("body", string(body)).Msg("submitting telemetry")
 		return errors.Errorf("submitting metrics (%s %s)", c.submissionURL, resp.Status)
 	}
 

--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -202,6 +202,9 @@ func (c *Cluster) Start(ctx context.Context) error {
 			c.running = true
 			c.Unlock()
 
+			// reset submit retries metric
+			c.check.SetCounter("collect_submit_retries", cgm.Tags{cgm.Tag{Category: "source", Value: release.NAME}}, 0)
+
 			go func() {
 				var wg sync.WaitGroup
 				wg.Add(len(c.collectors))


### PR DESCRIPTION
* upd: increase metric bucket size to 1000
* fix: typo in metric name
* upd: use `resultLogger` to identify source of submission errors/retries
* add: set `collect_submit_retries` to 0 at start of each collection run
