### PR TITLE
v0.5.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# v0.5.6
+
+* upd: sequential to use contextual logger for messages when submitting
+* add: use sequential for stream if not concurrent
+* add: status code to api response errors
+* add: sequential metric submitter (gaps)
+* add: option for concurrent metric submission
+* add: option for max metric bucket size for promtext
+* upd: use config option for max metric bucket size
+* fix: remove redundant call parameter for promtext
+
 # v0.5.5
 
 * upd: increase metric bucket size to 1000

--- a/cmd/args_circonus.go
+++ b/cmd/args_circonus.go
@@ -389,4 +389,44 @@ func init() {
 		}
 		viper.SetDefault(key, defaultValue)
 	}
+	{
+		const (
+			key          = keys.ConcurrentSubmissions
+			longOpt      = "concurrent-submissions"
+			envVar       = release.ENVPREFIX + "_CONCURRENT_SUBMISSIONS"
+			description  = "Submit metrics concurrently (disable if gaps appear)"
+			defaultValue = defaults.ConcurrentSubmissions
+		)
+
+		rootCmd.PersistentFlags().Bool(longOpt, defaultValue, envDescription(description, envVar))
+		flag := rootCmd.PersistentFlags().Lookup(longOpt)
+		flag.Hidden = true
+		if err := viper.BindPFlag(key, flag); err != nil {
+			bindFlagError(longOpt, err)
+		}
+		if err := viper.BindEnv(key, envVar); err != nil {
+			bindEnvError(envVar, err)
+		}
+		viper.SetDefault(key, defaultValue)
+	}
+	{
+		const (
+			key          = keys.MaxMetricBucketSize
+			longOpt      = "max-metric-bucket-size"
+			envVar       = release.ENVPREFIX + "_MAX_METRIC_BUCKET_SIZE"
+			description  = "Max metric bucket size for parsing prom metrics"
+			defaultValue = defaults.MaxMetricBucketSize
+		)
+
+		rootCmd.PersistentFlags().Uint(longOpt, defaultValue, envDescription(description, envVar))
+		flag := rootCmd.PersistentFlags().Lookup(longOpt)
+		flag.Hidden = true
+		if err := viper.BindPFlag(key, flag); err != nil {
+			bindFlagError(longOpt, err)
+		}
+		if err := viper.BindEnv(key, envVar); err != nil {
+			bindEnvError(envVar, err)
+		}
+		viper.SetDefault(key, defaultValue)
+	}
 }

--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -5,28 +5,28 @@
     name: circonus-kubernetes-agent
     labels:
       app.kubernetes.io/name: circonus-kubernetes-agent
-      app.kubernetes.io/version: v0.5.5
+      app.kubernetes.io/version: v0.5.6
   spec:
     selector:
       matchLabels:
         app.kubernetes.io/name: circonus-kubernetes-agent
-        app.kubernetes.io/version: v0.5.5
+        app.kubernetes.io/version: v0.5.6
     replicas: 1
     template:
       metadata:
         name: circonus-kubernetes-agent
         labels:
           app.kubernetes.io/name: circonus-kubernetes-agent
-          app.kubernetes.io/version: v0.5.5
+          app.kubernetes.io/version: v0.5.6
       spec:
         nodeSelector:
           kubernetes.io/os: linux
         serviceAccountName: circonus-kubernetes-agent
         containers:
           - name: circonus-kubernetes-agent
-            image: circonuslabs/circonus-kubernetes-agent:v0.5.5
+            image: circonuslabs/circonus-kubernetes-agent:v0.5.6
             ## for ARM64, remove line above and uncomment line below
-            #image: circonuslabs/circonus-kubernetes-agent-arm64:v0.5.5
+            #image: circonuslabs/circonus-kubernetes-agent-arm64:v0.5.6
             command: ["/circonus-kubernetes-agentd"]
             args: 
               #- --debug

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -63,6 +63,11 @@ func New() (*Agent, error) {
 	}
 
 	// Set the hidden settings based on viper
+	cfg.Circonus.ConcurrentSubmissions = viper.GetBool(keys.ConcurrentSubmissions)
+	cfg.Circonus.MaxMetricBucketSize = defaults.MaxMetricBucketSize
+	if viper.GetUint(keys.MaxMetricBucketSize) != defaults.MaxMetricBucketSize {
+		cfg.Circonus.MaxMetricBucketSize = viper.GetInt(keys.MaxMetricBucketSize)
+	}
 	cfg.Circonus.Base64Tags = defaults.Base64Tags
 	if viper.GetBool(keys.NoBase64) {
 		cfg.Circonus.Base64Tags = false

--- a/internal/circonus/check.go
+++ b/internal/circonus/check.go
@@ -41,6 +41,11 @@ type Stats struct {
 	SentSize  string
 }
 
+type MetricSet struct {
+	Metrics []byte
+	Logger  zerolog.Logger
+}
+
 type Check struct {
 	config          *config.Circonus
 	brokerTLSConfig *tls.Config
@@ -51,7 +56,7 @@ type Check struct {
 	stats           Stats
 	statsmu         sync.Mutex
 	metrics         *cgm.CirconusMetrics
-	metricQueue     chan []byte
+	metricQueue     chan MetricSet
 }
 
 func NewCheck(parentLogger zerolog.Logger, cfg *config.Circonus) (*Check, error) {
@@ -61,7 +66,7 @@ func NewCheck(parentLogger zerolog.Logger, cfg *config.Circonus) (*Check, error)
 	c := &Check{
 		config:      cfg,
 		log:         parentLogger.With().Str("pkg", "circonus.check").Logger(),
-		metricQueue: make(chan []byte),
+		metricQueue: make(chan MetricSet),
 	}
 
 	// output debug messages for hidden settings which are not DEFAULT

--- a/internal/circonus/submit.go
+++ b/internal/circonus/submit.go
@@ -277,6 +277,9 @@ func (c *Check) SubmitStream(ctx context.Context, metrics io.Reader, resultLogge
 	resp, err := retryClient.Do(req)
 	if err != nil {
 		resultLogger.Error().Err(err).Msg("making request")
+		c.metrics.IncrementWithTags("collect_submit_fails", cgm.Tags{
+			cgm.Tag{Category: "source", Value: release.NAME},
+		})
 		return err
 	}
 

--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -165,8 +165,7 @@ func (c *Cluster) Start(ctx context.Context) error {
 		go eventWatcher.Start(ctx, c.tlsConfig)
 	}
 
-	if c.check.ConcurrentSubmissions() {
-		// start the metric submitter
+	if !c.check.ConcurrentSubmissions() {
 		go c.check.Submitter(ctx)
 	}
 

--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -165,6 +165,11 @@ func (c *Cluster) Start(ctx context.Context) error {
 		go eventWatcher.Start(ctx, c.tlsConfig)
 	}
 
+	if c.check.ConcurrentSubmissions() {
+		// start the metric submitter
+		go c.check.Submitter(ctx)
+	}
+
 	c.logger.Info().Str("collection_interval", c.interval.String()).Time("next_collection", time.Now().Add(c.interval)).Msg("client started")
 
 	ticker := time.NewTicker(c.interval)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -64,11 +64,13 @@ type Circonus struct {
 	TraceSubmits      string `mapstructure:"trace_submits" json:"trace_submits" toml:"trace_submits" yaml:"trace_submits"` // trace metrics being sent to circonus
 	DefaultStreamtags string `mapstructure:"default_streamtags" json:"default_streamtags" toml:"default_streamtags" yaml:"default_streamtags"`
 	// hidden circonus settings for development and debugging
-	Base64Tags       bool `json:"-" toml:"-" yaml:"-"` //`mapstructure:"base64_tags" json:"base64_tags" toml:"base64_tags" yaml:"base64_tags"`
-	DryRun           bool `json:"-" toml:"-" yaml:"-"` //`mapstructure:"dry_run" json:"dry_run" toml:"dry_run" yaml:"dry_run"`                             // simulate sending metrics, print them to stdout
-	StreamMetrics    bool `json:"-" toml:"-" yaml:"-"` //`mapstructure:"stream_metrics" json:"stream_metrics" toml:"stream_metrics" yaml:"stream_metrics"` // use streaming metric submission format (applicable when using _ts)
-	UseGZIP          bool `json:"-" toml:"-" yaml:"-"` //`mapstructure:"use_gzip" json:"use_gzip" toml:"use_gzip" yaml:"use_gzip"`                         // compress metrics using gzip when submitting (broker may not support)
-	DebugSubmissions bool `json:"-" toml:"-" yaml:"-"`
+	Base64Tags            bool `json:"-" toml:"-" yaml:"-"` //`mapstructure:"base64_tags" json:"base64_tags" toml:"base64_tags" yaml:"base64_tags"`
+	DryRun                bool `json:"-" toml:"-" yaml:"-"` //`mapstructure:"dry_run" json:"dry_run" toml:"dry_run" yaml:"dry_run"`                             // simulate sending metrics, print them to stdout
+	StreamMetrics         bool `json:"-" toml:"-" yaml:"-"` //`mapstructure:"stream_metrics" json:"stream_metrics" toml:"stream_metrics" yaml:"stream_metrics"` // use streaming metric submission format (applicable when using _ts)
+	UseGZIP               bool `json:"-" toml:"-" yaml:"-"` //`mapstructure:"use_gzip" json:"use_gzip" toml:"use_gzip" yaml:"use_gzip"`                         // compress metrics using gzip when submitting (broker may not support)
+	DebugSubmissions      bool `json:"-" toml:"-" yaml:"-"`
+	ConcurrentSubmissions bool `json:"-" toml:"-" yaml:"-"`
+	MaxMetricBucketSize   int  `json:"-" toml:"-" yaml:"-"`
 }
 
 // API defines the circonus api configuration options

--- a/internal/config/defaults/defaults.go
+++ b/internal/config/defaults/defaults.go
@@ -38,11 +38,13 @@ const (
 	StreamMetrics = false
 	// these hidden settings are mainly for debugging
 	// the features default to ON and can be toggled OFF
-	NoBase64         = false
-	Base64Tags       = true
-	NoGZIP           = false
-	UseGZIP          = true
-	DebugSubmissions = false
+	ConcurrentSubmissions = false
+	MaxMetricBucketSize   = 0
+	NoBase64              = false
+	Base64Tags            = true
+	NoGZIP                = false
+	UseGZIP               = true
+	DebugSubmissions      = false
 
 	// General defaults
 

--- a/internal/config/keys/keys.go
+++ b/internal/config/keys/keys.go
@@ -86,6 +86,14 @@ const (
 
 	// hidden circonus settings for development and debugging
 
+	// ConcurrentSubmissions submit metrics to circonus concurrently
+	ConcurrentSubmissions = "circonus.concurrent_submissions"
+
+	// MaxMetricBucketSize defines a bucket size for parsing prom output - can save on memory
+	// to not queue up all of the metric-server metrics at one time and send them in smaller chunks
+	// 0 = no limit, any other number, metrics are sent in buckets of size
+	MaxMetricBucketSize = "circonus.max_metric_bucket_size"
+
 	// Base64Tags whether to encode tags with base64
 	Base64Tags = "circonus.base64_tags"
 	// NoBase64 disables using base64 encoding for stream tags (debugging)

--- a/internal/ksm/ksm.go
+++ b/internal/ksm/ksm.go
@@ -203,6 +203,12 @@ func (ksm *KSM) getServiceDefinition(tlsConfig *tls.Config) (*k8s.Service, error
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
+		ksm.check.IncrementCounter("collect_api_errors", cgm.Tags{
+			cgm.Tag{Category: "source", Value: release.NAME},
+			cgm.Tag{Category: "request", Value: "kube-state-metrics_service"},
+			cgm.Tag{Category: "target", Value: "api-server"},
+			cgm.Tag{Category: "code", Value: fmt.Sprintf("%d", resp.StatusCode)},
+		})
 		data, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
 			ksm.log.Error().Err(err).Str("url", reqURL).Msg("reading response")
@@ -248,7 +254,6 @@ func (ksm *KSM) metrics(ctx context.Context, tlsConfig *tls.Config, metricURL st
 			cgm.Tag{Category: "request", Value: "metrics"},
 			cgm.Tag{Category: "proxy", Value: "api-server"},
 			cgm.Tag{Category: "target", Value: "kube-state-metrics"},
-			cgm.Tag{Category: "code", Value: fmt.Sprintf("%d", resp.StatusCode)},
 		})
 		return err
 	}
@@ -262,6 +267,13 @@ func (ksm *KSM) metrics(ctx context.Context, tlsConfig *tls.Config, metricURL st
 	}, float64(time.Since(start).Milliseconds()))
 
 	if resp.StatusCode != http.StatusOK {
+		ksm.check.IncrementCounter("collect_api_errors", cgm.Tags{
+			cgm.Tag{Category: "source", Value: release.NAME},
+			cgm.Tag{Category: "request", Value: "metrics"},
+			cgm.Tag{Category: "proxy", Value: "api-server"},
+			cgm.Tag{Category: "target", Value: "kube-state-metrics"},
+			cgm.Tag{Category: "code", Value: fmt.Sprintf("%d", resp.StatusCode)},
+		})
 		data, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
 			ksm.log.Error().Err(err).Str("url", metricURL).Msg("reading response")
@@ -307,7 +319,6 @@ func (ksm *KSM) telemetry(ctx context.Context, tlsConfig *tls.Config, telemetryU
 			cgm.Tag{Category: "request", Value: "telemetry"},
 			cgm.Tag{Category: "proxy", Value: "api-server"},
 			cgm.Tag{Category: "target", Value: "kube-state-metrics"},
-			cgm.Tag{Category: "code", Value: fmt.Sprintf("%d", resp.StatusCode)},
 		})
 		return err
 	}
@@ -321,6 +332,13 @@ func (ksm *KSM) telemetry(ctx context.Context, tlsConfig *tls.Config, telemetryU
 	}, float64(time.Since(start).Milliseconds()))
 
 	if resp.StatusCode != http.StatusOK {
+		ksm.check.IncrementCounter("collect_api_errors", cgm.Tags{
+			cgm.Tag{Category: "source", Value: release.NAME},
+			cgm.Tag{Category: "request", Value: "telemetry"},
+			cgm.Tag{Category: "proxy", Value: "api-server"},
+			cgm.Tag{Category: "target", Value: "kube-state-metrics"},
+			cgm.Tag{Category: "code", Value: fmt.Sprintf("%d", resp.StatusCode)},
+		})
 		data, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
 			ksm.log.Error().Err(err).Str("url", telemetryURL).Msg("reading response")

--- a/internal/ksm/ksm.go
+++ b/internal/ksm/ksm.go
@@ -273,11 +273,11 @@ func (ksm *KSM) metrics(ctx context.Context, tlsConfig *tls.Config, metricURL st
 	measurementTags := []string{}
 
 	if ksm.check.StreamMetrics() {
-		if err := promtext.StreamMetrics(ctx, ksm.check, ksm.log, resp.Body, ksm.check, streamTags, measurementTags, ksm.ts); err != nil {
+		if err := promtext.StreamMetrics(ctx, ksm.check, ksm.log, resp.Body, streamTags, measurementTags, ksm.ts); err != nil {
 			return err
 		}
 	} else {
-		if err := promtext.QueueMetrics(ctx, ksm.check, ksm.log, resp.Body, ksm.check, streamTags, measurementTags, nil); err != nil {
+		if err := promtext.QueueMetrics(ctx, ksm.check, ksm.log, resp.Body, streamTags, measurementTags, nil); err != nil {
 			return err
 		}
 	}
@@ -330,11 +330,11 @@ func (ksm *KSM) telemetry(ctx context.Context, tlsConfig *tls.Config, telemetryU
 	measurementTags := []string{}
 
 	if ksm.check.StreamMetrics() {
-		if err := promtext.StreamMetrics(ctx, ksm.check, ksm.log, resp.Body, ksm.check, streamTags, measurementTags, ksm.ts); err != nil {
+		if err := promtext.StreamMetrics(ctx, ksm.check, ksm.log, resp.Body, streamTags, measurementTags, ksm.ts); err != nil {
 			return err
 		}
 	} else {
-		if err := promtext.QueueMetrics(ctx, ksm.check, ksm.log, resp.Body, ksm.check, streamTags, measurementTags, nil); err != nil {
+		if err := promtext.QueueMetrics(ctx, ksm.check, ksm.log, resp.Body, streamTags, measurementTags, nil); err != nil {
 			return err
 		}
 	}

--- a/internal/ksm/ksm.go
+++ b/internal/ksm/ksm.go
@@ -247,7 +247,9 @@ func (ksm *KSM) metrics(ctx context.Context, tlsConfig *tls.Config, metricURL st
 			cgm.Tag{Category: "source", Value: release.NAME},
 			cgm.Tag{Category: "request", Value: "metrics"},
 			cgm.Tag{Category: "proxy", Value: "api-server"},
-			cgm.Tag{Category: "target", Value: "kube-state-metrics"}})
+			cgm.Tag{Category: "target", Value: "kube-state-metrics"},
+			cgm.Tag{Category: "code", Value: fmt.Sprintf("%d", resp.StatusCode)},
+		})
 		return err
 	}
 	defer resp.Body.Close()
@@ -304,7 +306,9 @@ func (ksm *KSM) telemetry(ctx context.Context, tlsConfig *tls.Config, telemetryU
 			cgm.Tag{Category: "source", Value: release.NAME},
 			cgm.Tag{Category: "request", Value: "telemetry"},
 			cgm.Tag{Category: "proxy", Value: "api-server"},
-			cgm.Tag{Category: "target", Value: "kube-state-metrics"}})
+			cgm.Tag{Category: "target", Value: "kube-state-metrics"},
+			cgm.Tag{Category: "code", Value: fmt.Sprintf("%d", resp.StatusCode)},
+		})
 		return err
 	}
 	defer resp.Body.Close()

--- a/internal/ms/ms.go
+++ b/internal/ms/ms.go
@@ -9,6 +9,7 @@ package ms
 import (
 	"context"
 	"crypto/tls"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"sync"
@@ -127,7 +128,9 @@ func (ms *MS) Collect(ctx context.Context, tlsConfig *tls.Config, ts *time.Time)
 			cgm.Tag{Category: "source", Value: release.NAME},
 			cgm.Tag{Category: "request", Value: "metrics"},
 			cgm.Tag{Category: "proxy", Value: "api-server"},
-			cgm.Tag{Category: "target", Value: "metric-server"}})
+			cgm.Tag{Category: "target", Value: "metric-server"},
+			cgm.Tag{Category: "code", Value: fmt.Sprintf("%d", resp.StatusCode)},
+		})
 		ms.log.Error().Err(err).Str("url", metricsURL).Msg("metrics")
 		ms.Lock()
 		ms.running = false

--- a/internal/ms/ms.go
+++ b/internal/ms/ms.go
@@ -157,11 +157,11 @@ func (ms *MS) Collect(ctx context.Context, tlsConfig *tls.Config, ts *time.Time)
 	measurementTags := []string{}
 
 	if ms.check.StreamMetrics() {
-		if err := promtext.StreamMetrics(ctx, ms.check, ms.log, resp.Body, ms.check, streamTags, measurementTags, ts); err != nil {
+		if err := promtext.StreamMetrics(ctx, ms.check, ms.log, resp.Body, streamTags, measurementTags, ts); err != nil {
 			ms.log.Error().Err(err).Msg("formatting metrics")
 		}
 	} else {
-		if err := promtext.QueueMetrics(ctx, ms.check, ms.log, resp.Body, ms.check, streamTags, measurementTags, ts); err != nil {
+		if err := promtext.QueueMetrics(ctx, ms.check, ms.log, resp.Body, streamTags, measurementTags, ts); err != nil {
 			ms.log.Error().Err(err).Msg("formatting metrics")
 		}
 	}

--- a/internal/nodes/collector/collector.go
+++ b/internal/nodes/collector/collector.go
@@ -432,7 +432,6 @@ func (nc *Collector) summary(parentStreamTags []string, parentMeasurementTags []
 			cgm.Tag{Category: "request", Value: "stats/summary"},
 			cgm.Tag{Category: "proxy", Value: "api-server"},
 			cgm.Tag{Category: "target", Value: "kubelet"},
-			cgm.Tag{Category: "code", Value: fmt.Sprintf("%d", resp.StatusCode)},
 		})
 		nc.log.Error().Err(err).Str("req_url", reqURL).Msg("fetching summary stats")
 		return
@@ -451,6 +450,13 @@ func (nc *Collector) summary(parentStreamTags []string, parentMeasurementTags []
 	}
 
 	if resp.StatusCode != http.StatusOK {
+		nc.check.IncrementCounter("collect_api_errors", cgm.Tags{
+			cgm.Tag{Category: "source", Value: release.NAME},
+			cgm.Tag{Category: "request", Value: "stats/summary"},
+			cgm.Tag{Category: "proxy", Value: "api-server"},
+			cgm.Tag{Category: "target", Value: "kubelet"},
+			cgm.Tag{Category: "code", Value: fmt.Sprintf("%d", resp.StatusCode)},
+		})
 		data, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
 			nc.log.Error().Err(err).Str("url", reqURL).Msg("reading response")
@@ -750,7 +756,6 @@ func (nc *Collector) nmetrics(parentStreamTags []string, parentMeasurementTags [
 			cgm.Tag{Category: "request", Value: "metrics"},
 			cgm.Tag{Category: "proxy", Value: "api-server"},
 			cgm.Tag{Category: "target", Value: "kubelet"},
-			cgm.Tag{Category: "code", Value: fmt.Sprintf("%d", resp.StatusCode)},
 		})
 		nc.log.Error().Err(err).Str("url", reqURL).Msg("node metrics")
 		return
@@ -768,6 +773,13 @@ func (nc *Collector) nmetrics(parentStreamTags []string, parentMeasurementTags [
 	}
 
 	if resp.StatusCode != http.StatusOK {
+		nc.check.IncrementCounter("collect_api_errors", cgm.Tags{
+			cgm.Tag{Category: "source", Value: release.NAME},
+			cgm.Tag{Category: "request", Value: "metrics"},
+			cgm.Tag{Category: "proxy", Value: "api-server"},
+			cgm.Tag{Category: "target", Value: "kubelet"},
+			cgm.Tag{Category: "code", Value: fmt.Sprintf("%d", resp.StatusCode)},
+		})
 		data, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
 			nc.log.Error().Err(err).Str("url", reqURL).Msg("reading response")
@@ -818,7 +830,6 @@ func (nc *Collector) getPodLabels(ns string, name string) (bool, []string, error
 			cgm.Tag{Category: "source", Value: release.NAME},
 			cgm.Tag{Category: "request", Value: "pod-labels"},
 			cgm.Tag{Category: "target", Value: "api-server"},
-			cgm.Tag{Category: "code", Value: fmt.Sprintf("%d", resp.StatusCode)},
 		})
 		return collect, tags, err
 	}
@@ -831,6 +842,12 @@ func (nc *Collector) getPodLabels(ns string, name string) (bool, []string, error
 	}, float64(time.Since(start).Milliseconds()))
 
 	if resp.StatusCode != http.StatusOK {
+		nc.check.IncrementCounter("collect_api_errors", cgm.Tags{
+			cgm.Tag{Category: "source", Value: release.NAME},
+			cgm.Tag{Category: "request", Value: "pod-labels"},
+			cgm.Tag{Category: "target", Value: "api-server"},
+			cgm.Tag{Category: "code", Value: fmt.Sprintf("%d", resp.StatusCode)},
+		})
 		data, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
 			nc.log.Error().Err(err).Str("url", reqURL).Msg("reading response")

--- a/internal/nodes/collector/collector.go
+++ b/internal/nodes/collector/collector.go
@@ -773,11 +773,11 @@ func (nc *Collector) nmetrics(parentStreamTags []string, parentMeasurementTags [
 	}
 
 	if nc.check.StreamMetrics() {
-		if err := promtext.StreamMetrics(nc.ctx, nc.check, nc.log, resp.Body, nc.check, parentStreamTags, parentMeasurementTags, nc.ts); err != nil {
+		if err := promtext.StreamMetrics(nc.ctx, nc.check, nc.log, resp.Body, parentStreamTags, parentMeasurementTags, nc.ts); err != nil {
 			nc.log.Error().Err(err).Msg("parsing node metrics")
 		}
 	} else {
-		if err := promtext.QueueMetrics(nc.ctx, nc.check, nc.log, resp.Body, nc.check, parentStreamTags, parentMeasurementTags, nil); err != nil {
+		if err := promtext.QueueMetrics(nc.ctx, nc.check, nc.log, resp.Body, parentStreamTags, parentMeasurementTags, nil); err != nil {
 			nc.log.Error().Err(err).Msg("parsing node metrics")
 		}
 	}

--- a/internal/nodes/collector/collector.go
+++ b/internal/nodes/collector/collector.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"strconv"
@@ -430,7 +431,9 @@ func (nc *Collector) summary(parentStreamTags []string, parentMeasurementTags []
 			cgm.Tag{Category: "source", Value: release.NAME},
 			cgm.Tag{Category: "request", Value: "stats/summary"},
 			cgm.Tag{Category: "proxy", Value: "api-server"},
-			cgm.Tag{Category: "target", Value: "kubelet"}})
+			cgm.Tag{Category: "target", Value: "kubelet"},
+			cgm.Tag{Category: "code", Value: fmt.Sprintf("%d", resp.StatusCode)},
+		})
 		nc.log.Error().Err(err).Str("req_url", reqURL).Msg("fetching summary stats")
 		return
 	}
@@ -746,7 +749,9 @@ func (nc *Collector) nmetrics(parentStreamTags []string, parentMeasurementTags [
 			cgm.Tag{Category: "source", Value: release.NAME},
 			cgm.Tag{Category: "request", Value: "metrics"},
 			cgm.Tag{Category: "proxy", Value: "api-server"},
-			cgm.Tag{Category: "target", Value: "kubelet"}})
+			cgm.Tag{Category: "target", Value: "kubelet"},
+			cgm.Tag{Category: "code", Value: fmt.Sprintf("%d", resp.StatusCode)},
+		})
 		nc.log.Error().Err(err).Str("url", reqURL).Msg("node metrics")
 		return
 	}
@@ -812,7 +817,9 @@ func (nc *Collector) getPodLabels(ns string, name string) (bool, []string, error
 		nc.check.IncrementCounter("collect_api_errors", cgm.Tags{
 			cgm.Tag{Category: "source", Value: release.NAME},
 			cgm.Tag{Category: "request", Value: "pod-labels"},
-			cgm.Tag{Category: "target", Value: "api-server"}})
+			cgm.Tag{Category: "target", Value: "api-server"},
+			cgm.Tag{Category: "code", Value: fmt.Sprintf("%d", resp.StatusCode)},
+		})
 		return collect, tags, err
 	}
 	defer resp.Body.Close()

--- a/internal/nodes/nodes.go
+++ b/internal/nodes/nodes.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -202,7 +203,7 @@ func (n *Nodes) nodeList(tlsConfig *tls.Config) (*k8s.NodeList, error) {
 			cgm.Tag{Category: "source", Value: release.NAME},
 			cgm.Tag{Category: "request", Value: "node-list"},
 			cgm.Tag{Category: "target", Value: "api-server"},
-			cgm.Tag{Category: "units", Value: "milliseconds"},
+			cgm.Tag{Category: "code", Value: fmt.Sprintf("%d", resp.StatusCode)},
 		})
 		return nil, err
 	}


### PR DESCRIPTION
* upd: sequential to use contextual logger for messages when submitting
* add: use sequential for stream if not concurrent
* add: status code to api response errors
* add: sequential metric submitter (gaps)
* add: option for concurrent metric submission
* add: option for max metric bucket size for promtext
* upd: use config option for max metric bucket size
* fix: remove redundant call parameter for promtext
