### PR TITLE
v0.5.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# v0.5.7
+
+* add: option `--serial-submissions` to disable concurrent submissions
+* upd: default to concurrent submissions w/timestamp metrics
+* upd: deprecate streaming metrics as an option
+* fix: use metric queue for events
+* fix: ensure all metrics have timestamp, address drift on retries
+* fix: `/health` output
+
 # v0.5.6
 
 * upd: sequential to use contextual logger for messages when submitting

--- a/cmd/args_circonus.go
+++ b/cmd/args_circonus.go
@@ -327,26 +327,26 @@ func init() {
 		viper.SetDefault(key, defaultValue)
 	}
 
-	{
-		const (
-			key          = keys.StreamMetrics
-			longOpt      = "stream-metrics"
-			envVar       = release.ENVPREFIX + "_STREAM_METRICS"
-			description  = "Stream metrics (applicable when using _ts)"
-			defaultValue = defaults.StreamMetrics
-		)
+	// {
+	// 	const (
+	// 		key          = keys.StreamMetrics
+	// 		longOpt      = "stream-metrics"
+	// 		envVar       = release.ENVPREFIX + "_STREAM_METRICS"
+	// 		description  = "Stream metrics (applicable when using _ts)"
+	// 		defaultValue = defaults.StreamMetrics
+	// 	)
 
-		rootCmd.PersistentFlags().Bool(longOpt, defaultValue, envDescription(description, envVar))
-		flag := rootCmd.PersistentFlags().Lookup(longOpt)
-		flag.Hidden = true
-		if err := viper.BindPFlag(key, flag); err != nil {
-			bindFlagError(longOpt, err)
-		}
-		if err := viper.BindEnv(key, envVar); err != nil {
-			bindEnvError(envVar, err)
-		}
-		viper.SetDefault(key, defaultValue)
-	}
+	// 	rootCmd.PersistentFlags().Bool(longOpt, defaultValue, envDescription(description, envVar))
+	// 	flag := rootCmd.PersistentFlags().Lookup(longOpt)
+	// 	flag.Hidden = true
+	// 	if err := viper.BindPFlag(key, flag); err != nil {
+	// 		bindFlagError(longOpt, err)
+	// 	}
+	// 	if err := viper.BindEnv(key, envVar); err != nil {
+	// 		bindEnvError(envVar, err)
+	// 	}
+	// 	viper.SetDefault(key, defaultValue)
+	// }
 
 	{
 		const (

--- a/cmd/args_circonus.go
+++ b/cmd/args_circonus.go
@@ -389,13 +389,33 @@ func init() {
 		}
 		viper.SetDefault(key, defaultValue)
 	}
+	// {
+	// 	const (
+	// 		key          = keys.ConcurrentSubmissions
+	// 		longOpt      = "concurrent-submissions"
+	// 		envVar       = release.ENVPREFIX + "_CONCURRENT_SUBMISSIONS"
+	// 		description  = "Submit metrics concurrently (disable if gaps appear)"
+	// 		defaultValue = defaults.ConcurrentSubmissions
+	// 	)
+
+	// 	rootCmd.PersistentFlags().Bool(longOpt, defaultValue, envDescription(description, envVar))
+	// 	flag := rootCmd.PersistentFlags().Lookup(longOpt)
+	// 	flag.Hidden = true
+	// 	if err := viper.BindPFlag(key, flag); err != nil {
+	// 		bindFlagError(longOpt, err)
+	// 	}
+	// 	if err := viper.BindEnv(key, envVar); err != nil {
+	// 		bindEnvError(envVar, err)
+	// 	}
+	// 	viper.SetDefault(key, defaultValue)
+	// }
 	{
 		const (
-			key          = keys.ConcurrentSubmissions
-			longOpt      = "concurrent-submissions"
-			envVar       = release.ENVPREFIX + "_CONCURRENT_SUBMISSIONS"
-			description  = "Submit metrics concurrently (disable if gaps appear)"
-			defaultValue = defaults.ConcurrentSubmissions
+			key          = keys.SerialSubmissions
+			longOpt      = "serial-submissions"
+			envVar       = release.ENVPREFIX + "_SERIAL_SUBMISSIONS"
+			description  = "Submit metrics serially (enable if gaps appear)"
+			defaultValue = defaults.SerialSubmissions
 		)
 
 		rootCmd.PersistentFlags().Bool(longOpt, defaultValue, envDescription(description, envVar))

--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -5,28 +5,28 @@
     name: circonus-kubernetes-agent
     labels:
       app.kubernetes.io/name: circonus-kubernetes-agent
-      app.kubernetes.io/version: v0.5.6
+      app.kubernetes.io/version: v0.5.7
   spec:
     selector:
       matchLabels:
         app.kubernetes.io/name: circonus-kubernetes-agent
-        app.kubernetes.io/version: v0.5.6
+        app.kubernetes.io/version: v0.5.7
     replicas: 1
     template:
       metadata:
         name: circonus-kubernetes-agent
         labels:
           app.kubernetes.io/name: circonus-kubernetes-agent
-          app.kubernetes.io/version: v0.5.6
+          app.kubernetes.io/version: v0.5.7
       spec:
         nodeSelector:
           kubernetes.io/os: linux
         serviceAccountName: circonus-kubernetes-agent
         containers:
           - name: circonus-kubernetes-agent
-            image: circonuslabs/circonus-kubernetes-agent:v0.5.6
+            image: circonuslabs/circonus-kubernetes-agent:v0.5.7
             ## for ARM64, remove line above and uncomment line below
-            #image: circonuslabs/circonus-kubernetes-agent-arm64:v0.5.6
+            #image: circonuslabs/circonus-kubernetes-agent-arm64:v0.5.7
             command: ["/circonus-kubernetes-agentd"]
             args: 
               #- --debug

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -64,7 +64,9 @@ func New() (*Agent, error) {
 
 	// Set the hidden settings based on viper
 	cfg.Circonus.ConcurrentSubmissions = defaults.ConcurrentSubmissions
-	if cfg.Circonus.SerialSubmissions {
+	cfg.Circonus.SerialSubmissions = defaults.SerialSubmissions
+	if viper.GetBool(keys.SerialSubmissions) != defaults.SerialSubmissions {
+		cfg.Circonus.SerialSubmissions = true
 		cfg.Circonus.ConcurrentSubmissions = false
 	}
 	cfg.Circonus.MaxMetricBucketSize = defaults.MaxMetricBucketSize
@@ -80,7 +82,7 @@ func New() (*Agent, error) {
 		cfg.Circonus.UseGZIP = false
 	}
 	cfg.Circonus.DryRun = viper.GetBool(keys.DryRun)
-	cfg.Circonus.StreamMetrics = viper.GetBool(keys.StreamMetrics)
+	// cfg.Circonus.StreamMetrics = viper.GetBool(keys.StreamMetrics)
 	cfg.Circonus.DebugSubmissions = viper.GetBool(keys.DebugSubmissions)
 
 	if len(cfg.Clusters) > 0 { // multiple clusters

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -117,7 +117,7 @@ func New() (*Agent, error) {
 						expvar.Handler().ServeHTTP(w, r)
 					case "/health", "/health/":
 						w.WriteHeader(http.StatusOK)
-						fmt.Fprintf(w, "Alive")
+						fmt.Fprintln(w, "Alive")
 					default:
 						http.NotFound(w, r)
 					}

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -63,7 +63,10 @@ func New() (*Agent, error) {
 	}
 
 	// Set the hidden settings based on viper
-	cfg.Circonus.ConcurrentSubmissions = viper.GetBool(keys.ConcurrentSubmissions)
+	cfg.Circonus.ConcurrentSubmissions = defaults.ConcurrentSubmissions
+	if cfg.Circonus.SerialSubmissions {
+		cfg.Circonus.ConcurrentSubmissions = false
+	}
 	cfg.Circonus.MaxMetricBucketSize = defaults.MaxMetricBucketSize
 	if viper.GetUint(keys.MaxMetricBucketSize) != defaults.MaxMetricBucketSize {
 		cfg.Circonus.MaxMetricBucketSize = viper.GetInt(keys.MaxMetricBucketSize)

--- a/internal/circonus/check.go
+++ b/internal/circonus/check.go
@@ -79,14 +79,14 @@ func NewCheck(parentLogger zerolog.Logger, cfg *config.Circonus) (*Check, error)
 	if cfg.DryRun != defaults.DryRun {
 		c.log.Info().Bool("enabled", cfg.DryRun).Msg("dry run")
 	}
-	if cfg.StreamMetrics != defaults.StreamMetrics {
-		c.log.Info().Bool("enabled", cfg.StreamMetrics).Msg("streaming metrics format")
-	}
+	// if cfg.StreamMetrics != defaults.StreamMetrics {
+	// 	c.log.Info().Bool("enabled", cfg.StreamMetrics).Msg("streaming metrics format")
+	// }
 	if cfg.DebugSubmissions != defaults.DebugSubmissions {
 		c.log.Info().Bool("enabled", cfg.DebugSubmissions).Msg("debug submissions")
 	}
-	if cfg.ConcurrentSubmissions != defaults.ConcurrentSubmissions {
-		c.log.Info().Bool("enabled", cfg.ConcurrentSubmissions).Msg("concurrent submissions")
+	if cfg.SerialSubmissions != defaults.SerialSubmissions {
+		c.log.Info().Bool("enabled", cfg.SerialSubmissions).Msg("serial submissions")
 	}
 	if cfg.MaxMetricBucketSize != defaults.MaxMetricBucketSize {
 		c.log.Info().Int("max_metric_bucket_size", cfg.MaxMetricBucketSize).Msg("max metric bucket size")
@@ -140,10 +140,10 @@ func (c *Check) UseCompression() bool {
 	return c.config.UseGZIP
 }
 
-// StreamMetrics indicates whether to stream metrics (use when multiple samples for same metric name with different timestamps)
-func (c *Check) StreamMetrics() bool {
-	return c.config.StreamMetrics
-}
+// // StreamMetrics indicates whether to stream metrics (use when multiple samples for same metric name with different timestamps)
+// func (c *Check) StreamMetrics() bool {
+// 	return c.config.StreamMetrics
+// }
 
 // DebugSubmissions will dump the submission request to stdout
 func (c *Check) DebugSubmissions() bool {

--- a/internal/circonus/metrics.go
+++ b/internal/circonus/metrics.go
@@ -163,7 +163,7 @@ func (c *Check) WriteMetricSample(
 	}
 
 	var metricSample string
-	if timestamp != nil {
+	if timestamp != nil && (metricType != MetricTypeHistogram && metricType != MetricTypeCumulativeHistogram) {
 		metricSample = fmt.Sprintf(
 			`{"%s":{"_type":"%s","_value":%v,"_ts":%d}}`,
 			taggedMetricName,
@@ -255,7 +255,7 @@ func (c *Check) QueueMetricSample(
 		Value: val,
 	}
 
-	if timestamp != nil {
+	if timestamp != nil && (metricType != MetricTypeHistogram && metricType != MetricTypeCumulativeHistogram) {
 		metricSample.Timestamp = makeTimestamp(timestamp)
 	}
 

--- a/internal/circonus/metrics.go
+++ b/internal/circonus/metrics.go
@@ -8,7 +8,6 @@ package circonus
 import (
 	"errors"
 	"fmt"
-	"io"
 	"regexp"
 	"strings"
 	"time"
@@ -108,84 +107,84 @@ func (c *Check) SetCounter(metricName string, tags cgm.Tags, value uint64) {
 	}
 }
 
-// WriteMetricSample to queue for submission
-func (c *Check) WriteMetricSample(
-	metricDest io.Writer,
-	metricName,
-	metricType string,
-	streamTags,
-	measurementTags []string,
-	value interface{},
-	timestamp *time.Time) error {
+// // WriteMetricSample to queue for submission
+// func (c *Check) WriteMetricSample(
+// 	metricDest io.Writer,
+// 	metricName,
+// 	metricType string,
+// 	streamTags,
+// 	measurementTags []string,
+// 	value interface{},
+// 	timestamp *time.Time) error {
 
-	if metricDest == nil {
-		return errors.New("invalid metric destination (nil)")
-	}
-	if metricName == "" {
-		return errors.New("invalid metric name (empty)")
-	}
-	if metricType == "" {
-		return errors.New("invalid metric type (empty)")
-	}
+// 	if metricDest == nil {
+// 		return errors.New("invalid metric destination (nil)")
+// 	}
+// 	if metricName == "" {
+// 		return errors.New("invalid metric name (empty)")
+// 	}
+// 	if metricType == "" {
+// 		return errors.New("invalid metric type (empty)")
+// 	}
 
-	streamTagList := strings.Split(c.config.DefaultStreamtags, ",")
-	streamTagList = append(streamTagList, streamTags...)
+// 	streamTagList := strings.Split(c.config.DefaultStreamtags, ",")
+// 	streamTagList = append(streamTagList, streamTags...)
 
-	if len(streamTagList)+len(measurementTags) > MaxTags {
-		c.log.Warn().
-			Str("metric_name", metricName).
-			Strs("stream_tags", streamTagList).
-			Strs("measurement_tags", measurementTags).
-			Int("num_tags", len(streamTagList)+len(measurementTags)).
-			Int("max_tags", MaxTags).
-			Msg("max metric tags exceeded, discarding")
-		return nil
-	}
+// 	if len(streamTagList)+len(measurementTags) > MaxTags {
+// 		c.log.Warn().
+// 			Str("metric_name", metricName).
+// 			Strs("stream_tags", streamTagList).
+// 			Strs("measurement_tags", measurementTags).
+// 			Int("num_tags", len(streamTagList)+len(measurementTags)).
+// 			Int("max_tags", MaxTags).
+// 			Msg("max metric tags exceeded, discarding")
+// 		return nil
+// 	}
 
-	taggedMetricName := c.taggedName(metricName, streamTagList, measurementTags)
+// 	taggedMetricName := c.taggedName(metricName, streamTagList, measurementTags)
 
-	if len(taggedMetricName) > MaxMetricNameLen {
-		c.log.Warn().
-			Str("metric_name", taggedMetricName).
-			Int("encoded_len", len(taggedMetricName)).
-			Int("max_len", MaxMetricNameLen).
-			Msg("max metric name length exceeded, discarding")
-		return nil
-	}
+// 	if len(taggedMetricName) > MaxMetricNameLen {
+// 		c.log.Warn().
+// 			Str("metric_name", taggedMetricName).
+// 			Int("encoded_len", len(taggedMetricName)).
+// 			Int("max_len", MaxMetricNameLen).
+// 			Msg("max metric name length exceeded, discarding")
+// 		return nil
+// 	}
 
-	if !metricTypeRx.MatchString(metricType) {
-		return fmt.Errorf("unrecognized circonus metric type (%s)", metricType)
-	}
+// 	if !metricTypeRx.MatchString(metricType) {
+// 		return fmt.Errorf("unrecognized circonus metric type (%s)", metricType)
+// 	}
 
-	val := value
-	if metricType == "s" {
-		val = fmt.Sprintf("%q", value.(string))
-	}
+// 	val := value
+// 	if metricType == "s" {
+// 		val = fmt.Sprintf("%q", value.(string))
+// 	}
 
-	var metricSample string
-	if timestamp != nil && (metricType != MetricTypeHistogram && metricType != MetricTypeCumulativeHistogram) {
-		metricSample = fmt.Sprintf(
-			`{"%s":{"_type":"%s","_value":%v,"_ts":%d}}`,
-			taggedMetricName,
-			metricType,
-			val,
-			makeTimestamp(timestamp),
-		)
-	} else {
-		metricSample = fmt.Sprintf(
-			`{"%s":{"_type":"%s","_value":%v}}`,
-			taggedMetricName,
-			metricType,
-			val,
-		)
-	}
+// 	var metricSample string
+// 	if timestamp != nil && (metricType != MetricTypeHistogram && metricType != MetricTypeCumulativeHistogram) {
+// 		metricSample = fmt.Sprintf(
+// 			`{"%s":{"_type":"%s","_value":%v,"_ts":%d}}`,
+// 			taggedMetricName,
+// 			metricType,
+// 			val,
+// 			makeTimestamp(timestamp),
+// 		)
+// 	} else {
+// 		metricSample = fmt.Sprintf(
+// 			`{"%s":{"_type":"%s","_value":%v}}`,
+// 			taggedMetricName,
+// 			metricType,
+// 			val,
+// 		)
+// 	}
 
-	_, err := fmt.Fprintln(metricDest, metricSample)
-	if err != nil {
-		return err
-	}
-	return nil
-}
+// 	_, err := fmt.Fprintln(metricDest, metricSample)
+// 	if err != nil {
+// 		return err
+// 	}
+// 	return nil
+// }
 
 // QueueMetricSample to queue for submission
 func (c *Check) QueueMetricSample(

--- a/internal/circonus/submit.go
+++ b/internal/circonus/submit.go
@@ -123,24 +123,24 @@ func (c *Check) SubmitQueue(ctx context.Context, metrics map[string]MetricSample
 	return nil
 }
 
-// SubmitStream sends metrics to a circonus trap
-func (c *Check) SubmitStream(ctx context.Context, metrics io.Reader, resultLogger zerolog.Logger) error {
-	if metrics == nil {
-		return errors.New("invalid metrics (nil)")
-	}
+// // SubmitStream sends metrics to a circonus trap
+// func (c *Check) SubmitStream(ctx context.Context, metrics io.Reader, resultLogger zerolog.Logger) error {
+// 	if metrics == nil {
+// 		return errors.New("invalid metrics (nil)")
+// 	}
 
-	data, err := ioutil.ReadAll(metrics)
-	if err != nil {
-		return errors.Wrap(err, "reading metrics")
-	}
+// 	data, err := ioutil.ReadAll(metrics)
+// 	if err != nil {
+// 		return errors.Wrap(err, "reading metrics")
+// 	}
 
-	if c.ConcurrentSubmissions() {
-		return c.Submit(ctx, bytes.NewReader(data), resultLogger)
-	}
+// 	if c.ConcurrentSubmissions() {
+// 		return c.Submit(ctx, bytes.NewReader(data), resultLogger)
+// 	}
 
-	c.AddMetricSet(data, resultLogger)
-	return nil
-}
+// 	c.AddMetricSet(data, resultLogger)
+// 	return nil
+// }
 
 // Submit sends metrics to a circonus trap
 func (c *Check) Submit(ctx context.Context, metrics io.Reader, resultLogger zerolog.Logger) error {

--- a/internal/circonus/submit.go
+++ b/internal/circonus/submit.go
@@ -58,10 +58,22 @@ func (c *Check) Submitter(ctx context.Context) {
 	}
 }
 
-func (c *Check) FlushCGM(ctx context.Context) {
+func (c *Check) FlushCGM(ctx context.Context, ts *time.Time) {
 	if c.metrics != nil {
-		m := c.metrics.FlushMetrics()
-		data, err := json.Marshal(m)
+		// TODO: add timestamp support to CGM (e.g. FlushMetricsWithTimestamp(ts))
+		metrics := make(map[string]MetricSample)
+		for mn, mv := range *(c.metrics.FlushMetrics()) {
+			ms := MetricSample{
+				Value: mv.Value,
+				Type:  mv.Type,
+			}
+			if ms.Type != MetricTypeHistogram {
+				ms.Timestamp = makeTimestamp(ts)
+			}
+			metrics[mn] = ms
+		}
+
+		data, err := json.Marshal(metrics)
 		if err != nil {
 			c.log.Warn().Err(err).Msg("encoding metrics")
 			return
@@ -267,13 +279,13 @@ func (c *Check) Submit(ctx context.Context, metrics io.Reader, resultLogger zero
 	retryClient.HTTPClient = client
 	retryClient.Logger = logshim{logh: c.log.With().Str("pkg", "retryablehttp").Logger()}
 	retryClient.RetryWaitMin = 50 * time.Millisecond
-	retryClient.RetryWaitMax = 2 * time.Second
+	retryClient.RetryWaitMax = 1 * time.Second
 	retryClient.RetryMax = 10
 	retryClient.RequestLogHook = func(l retryablehttp.Logger, r *http.Request, attempt int) {
 		if attempt > 0 {
 			c.metrics.IncrementWithTags("collect_submit_retries", cgm.Tags{cgm.Tag{Category: "source", Value: release.NAME}})
 			reqStart = time.Now()
-			resultLogger.Warn().Str("url", r.URL.String()).Int("attempt", attempt).Msg("retrying...")
+			resultLogger.Warn().Str("url", r.URL.String()).Int("retry", attempt).Msg("retrying...")
 		}
 	}
 	retryClient.ResponseLogHook = func(l retryablehttp.Logger, r *http.Response) {

--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -262,7 +262,7 @@ func (c *Cluster) Start(ctx context.Context) error {
 					c.check.AddGauge("collect_interval", streamTags, uint64(c.interval.Milliseconds()))
 				}
 
-				c.check.FlushCGM(ctx)
+				c.check.FlushCGM(ctx, &start)
 
 				c.logger.Info().
 					Interface("metrics_sent", cstats).

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -70,6 +70,7 @@ type Circonus struct {
 	UseGZIP               bool `json:"-" toml:"-" yaml:"-"` //`mapstructure:"use_gzip" json:"use_gzip" toml:"use_gzip" yaml:"use_gzip"`                         // compress metrics using gzip when submitting (broker may not support)
 	DebugSubmissions      bool `json:"-" toml:"-" yaml:"-"`
 	ConcurrentSubmissions bool `json:"-" toml:"-" yaml:"-"`
+	SerialSubmissions     bool `json:"-" toml:"-" yaml:"-"`
 	MaxMetricBucketSize   int  `json:"-" toml:"-" yaml:"-"`
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -64,9 +64,9 @@ type Circonus struct {
 	TraceSubmits      string `mapstructure:"trace_submits" json:"trace_submits" toml:"trace_submits" yaml:"trace_submits"` // trace metrics being sent to circonus
 	DefaultStreamtags string `mapstructure:"default_streamtags" json:"default_streamtags" toml:"default_streamtags" yaml:"default_streamtags"`
 	// hidden circonus settings for development and debugging
-	Base64Tags            bool `json:"-" toml:"-" yaml:"-"` //`mapstructure:"base64_tags" json:"base64_tags" toml:"base64_tags" yaml:"base64_tags"`
-	DryRun                bool `json:"-" toml:"-" yaml:"-"` //`mapstructure:"dry_run" json:"dry_run" toml:"dry_run" yaml:"dry_run"`                             // simulate sending metrics, print them to stdout
-	StreamMetrics         bool `json:"-" toml:"-" yaml:"-"` //`mapstructure:"stream_metrics" json:"stream_metrics" toml:"stream_metrics" yaml:"stream_metrics"` // use streaming metric submission format (applicable when using _ts)
+	Base64Tags bool `json:"-" toml:"-" yaml:"-"` //`mapstructure:"base64_tags" json:"base64_tags" toml:"base64_tags" yaml:"base64_tags"`
+	DryRun     bool `json:"-" toml:"-" yaml:"-"` //`mapstructure:"dry_run" json:"dry_run" toml:"dry_run" yaml:"dry_run"`                             // simulate sending metrics, print them to stdout
+	// StreamMetrics         bool `json:"-" toml:"-" yaml:"-"` //`mapstructure:"stream_metrics" json:"stream_metrics" toml:"stream_metrics" yaml:"stream_metrics"` // use streaming metric submission format (applicable when using _ts)
 	UseGZIP               bool `json:"-" toml:"-" yaml:"-"` //`mapstructure:"use_gzip" json:"use_gzip" toml:"use_gzip" yaml:"use_gzip"`                         // compress metrics using gzip when submitting (broker may not support)
 	DebugSubmissions      bool `json:"-" toml:"-" yaml:"-"`
 	ConcurrentSubmissions bool `json:"-" toml:"-" yaml:"-"`

--- a/internal/config/defaults/defaults.go
+++ b/internal/config/defaults/defaults.go
@@ -38,7 +38,8 @@ const (
 	StreamMetrics = false
 	// these hidden settings are mainly for debugging
 	// the features default to ON and can be toggled OFF
-	ConcurrentSubmissions = false
+	ConcurrentSubmissions = true
+	SerialSubmissons      = false
 	MaxMetricBucketSize   = 0
 	NoBase64              = false
 	Base64Tags            = true

--- a/internal/config/defaults/defaults.go
+++ b/internal/config/defaults/defaults.go
@@ -34,8 +34,8 @@ const (
 	CheckTitle         = ""
 	TraceSubmits       = ""
 	// hidden circonus settings for development and debugging
-	DryRun        = false
-	StreamMetrics = false
+	DryRun = false
+	// StreamMetrics = false
 	// these hidden settings are mainly for debugging
 	// the features default to ON and can be toggled OFF
 	ConcurrentSubmissions = true

--- a/internal/config/defaults/defaults.go
+++ b/internal/config/defaults/defaults.go
@@ -39,7 +39,7 @@ const (
 	// these hidden settings are mainly for debugging
 	// the features default to ON and can be toggled OFF
 	ConcurrentSubmissions = true
-	SerialSubmissons      = false
+	SerialSubmissions     = false
 	MaxMetricBucketSize   = 0
 	NoBase64              = false
 	Base64Tags            = true

--- a/internal/config/keys/keys.go
+++ b/internal/config/keys/keys.go
@@ -105,7 +105,7 @@ const (
 	DryRun = "circonus.dry_run"
 
 	// StreamMetrics use streaming metric submission format
-	StreamMetrics = "circonus.stream_metrics"
+	// StreamMetrics = "circonus.stream_metrics"
 
 	// UseGZIP when submitting
 	UseGZIP = "circonus.use_gzip"

--- a/internal/config/keys/keys.go
+++ b/internal/config/keys/keys.go
@@ -88,6 +88,8 @@ const (
 
 	// ConcurrentSubmissions submit metrics to circonus concurrently
 	ConcurrentSubmissions = "circonus.concurrent_submissions"
+	// SerialSubmissions submit metrics serially
+	SerialSubmissions = "circonus.serial_submissions"
 
 	// MaxMetricBucketSize defines a bucket size for parsing prom output - can save on memory
 	// to not queue up all of the metric-server metrics at one time and send them in smaller chunks

--- a/internal/ksm/ksm.go
+++ b/internal/ksm/ksm.go
@@ -291,7 +291,7 @@ func (ksm *KSM) metrics(ctx context.Context, tlsConfig *tls.Config, metricURL st
 			return err
 		}
 	} else {
-		if err := promtext.QueueMetrics(ctx, ksm.check, ksm.log, resp.Body, streamTags, measurementTags, nil); err != nil {
+		if err := promtext.QueueMetrics(ctx, ksm.check, ksm.log, resp.Body, streamTags, measurementTags, ksm.ts); err != nil {
 			return err
 		}
 	}
@@ -356,7 +356,7 @@ func (ksm *KSM) telemetry(ctx context.Context, tlsConfig *tls.Config, telemetryU
 			return err
 		}
 	} else {
-		if err := promtext.QueueMetrics(ctx, ksm.check, ksm.log, resp.Body, streamTags, measurementTags, nil); err != nil {
+		if err := promtext.QueueMetrics(ctx, ksm.check, ksm.log, resp.Body, streamTags, measurementTags, ksm.ts); err != nil {
 			return err
 		}
 	}

--- a/internal/ksm/ksm.go
+++ b/internal/ksm/ksm.go
@@ -286,15 +286,15 @@ func (ksm *KSM) metrics(ctx context.Context, tlsConfig *tls.Config, metricURL st
 	streamTags := []string{"source:kube-state-metrics", "source_type:metrics"}
 	measurementTags := []string{}
 
-	if ksm.check.StreamMetrics() {
-		if err := promtext.StreamMetrics(ctx, ksm.check, ksm.log, resp.Body, streamTags, measurementTags, ksm.ts); err != nil {
-			return err
-		}
-	} else {
-		if err := promtext.QueueMetrics(ctx, ksm.check, ksm.log, resp.Body, streamTags, measurementTags, ksm.ts); err != nil {
-			return err
-		}
+	// if ksm.check.StreamMetrics() {
+	// 	if err := promtext.StreamMetrics(ctx, ksm.check, ksm.log, resp.Body, streamTags, measurementTags, ksm.ts); err != nil {
+	// 		return err
+	// 	}
+	// } else {
+	if err := promtext.QueueMetrics(ctx, ksm.check, ksm.log, resp.Body, streamTags, measurementTags, ksm.ts); err != nil {
+		return err
 	}
+	// }
 
 	return nil
 }
@@ -351,15 +351,15 @@ func (ksm *KSM) telemetry(ctx context.Context, tlsConfig *tls.Config, telemetryU
 	streamTags := []string{"source:kube-state-metrics", "source_type:telemetry"}
 	measurementTags := []string{}
 
-	if ksm.check.StreamMetrics() {
-		if err := promtext.StreamMetrics(ctx, ksm.check, ksm.log, resp.Body, streamTags, measurementTags, ksm.ts); err != nil {
-			return err
-		}
-	} else {
-		if err := promtext.QueueMetrics(ctx, ksm.check, ksm.log, resp.Body, streamTags, measurementTags, ksm.ts); err != nil {
-			return err
-		}
+	// if ksm.check.StreamMetrics() {
+	// 	if err := promtext.StreamMetrics(ctx, ksm.check, ksm.log, resp.Body, streamTags, measurementTags, ksm.ts); err != nil {
+	// 		return err
+	// 	}
+	// } else {
+	if err := promtext.QueueMetrics(ctx, ksm.check, ksm.log, resp.Body, streamTags, measurementTags, ksm.ts); err != nil {
+		return err
 	}
+	// }
 
 	return nil
 }

--- a/internal/ms/ms.go
+++ b/internal/ms/ms.go
@@ -165,15 +165,15 @@ func (ms *MS) Collect(ctx context.Context, tlsConfig *tls.Config, ts *time.Time)
 	streamTags := []string{"source:metrics-server"}
 	measurementTags := []string{}
 
-	if ms.check.StreamMetrics() {
-		if err := promtext.StreamMetrics(ctx, ms.check, ms.log, resp.Body, streamTags, measurementTags, ts); err != nil {
-			ms.log.Error().Err(err).Msg("formatting metrics")
-		}
-	} else {
-		if err := promtext.QueueMetrics(ctx, ms.check, ms.log, resp.Body, streamTags, measurementTags, ts); err != nil {
-			ms.log.Error().Err(err).Msg("formatting metrics")
-		}
+	// if ms.check.StreamMetrics() {
+	// 	if err := promtext.StreamMetrics(ctx, ms.check, ms.log, resp.Body, streamTags, measurementTags, ts); err != nil {
+	// 		ms.log.Error().Err(err).Msg("formatting metrics")
+	// 	}
+	// } else {
+	if err := promtext.QueueMetrics(ctx, ms.check, ms.log, resp.Body, streamTags, measurementTags, ts); err != nil {
+		ms.log.Error().Err(err).Msg("formatting metrics")
 	}
+	// }
 
 	ms.check.AddHistSample("collect_latency", cgm.Tags{
 		cgm.Tag{Category: "source", Value: release.NAME},

--- a/internal/nodes/collector/collector.go
+++ b/internal/nodes/collector/collector.go
@@ -7,7 +7,6 @@
 package collector
 
 import (
-	"bytes"
 	"context"
 	"crypto/tls"
 	"encoding/json"
@@ -114,111 +113,111 @@ func (nc *Collector) meta(parentStreamTags []string, parentMeasurementTags []str
 		return
 	}
 
-	if nc.check.StreamMetrics() {
+	// if nc.check.StreamMetrics() {
 
-		var buf bytes.Buffer
+	// 	var buf bytes.Buffer
 
-		{ // meta
-			var streamTags []string
-			streamTags = append(streamTags, parentStreamTags...)
-			streamTags = append(streamTags, []string{
-				"kernel_version:" + nc.node.Status.NodeInfo.KernelVersion,
-				"os_image:" + nc.node.Status.NodeInfo.OSImage,
-				"kublet_version:" + nc.node.Status.NodeInfo.KubeletVersion,
-			}...)
-			for k, v := range nc.node.Metadata.Labels {
-				streamTags = append(streamTags, k+":"+v)
-			}
-			_ = nc.check.WriteMetricSample(
-				&buf,
-				"node",
-				circonus.MetricTypeString,
-				streamTags, parentMeasurementTags,
-				nc.node.Metadata.Name,
-				nc.ts)
-		}
+	// 	{ // meta
+	// 		var streamTags []string
+	// 		streamTags = append(streamTags, parentStreamTags...)
+	// 		streamTags = append(streamTags, []string{
+	// 			"kernel_version:" + nc.node.Status.NodeInfo.KernelVersion,
+	// 			"os_image:" + nc.node.Status.NodeInfo.OSImage,
+	// 			"kublet_version:" + nc.node.Status.NodeInfo.KubeletVersion,
+	// 		}...)
+	// 		for k, v := range nc.node.Metadata.Labels {
+	// 			streamTags = append(streamTags, k+":"+v)
+	// 		}
+	// 		_ = nc.check.WriteMetricSample(
+	// 			&buf,
+	// 			"node",
+	// 			circonus.MetricTypeString,
+	// 			streamTags, parentMeasurementTags,
+	// 			nc.node.Metadata.Name,
+	// 			nc.ts)
+	// 	}
 
-		{ // conditions
-			var streamTags []string
-			streamTags = append(streamTags, parentStreamTags...)
-			streamTags = append(streamTags, "status:condition")
-			for _, cond := range nc.node.Status.Conditions {
-				if nc.done() {
-					break
-				}
-				_ = nc.check.WriteMetricSample(
-					&buf,
-					cond.Type,
-					circonus.MetricTypeString,
-					streamTags, parentMeasurementTags,
-					cond.Message,
-					nc.ts)
-			}
-		}
-		{ // capacity and allocatable
-			var streamTags []string
-			streamTags = append(streamTags, parentStreamTags...)
-			if v, err := strconv.Atoi(nc.node.Status.Capacity.CPU); err == nil {
-				_ = nc.check.WriteMetricSample(
-					&buf,
-					"capacity_cpu",
-					circonus.MetricTypeUint64,
-					streamTags, parentMeasurementTags,
-					uint64(v),
-					nc.ts)
-			} else {
-				nc.log.Warn().Err(err).Str("cpu", nc.node.Status.Capacity.CPU).Msg("converting capacity.cpu")
-			}
-			if v, err := strconv.Atoi(nc.node.Status.Capacity.Pods); err == nil {
-				_ = nc.check.WriteMetricSample(
-					&buf,
-					"capacity_pods",
-					circonus.MetricTypeUint64,
-					streamTags, parentMeasurementTags,
-					uint64(v),
-					nc.ts)
-			} else {
-				nc.log.Warn().Err(err).Str("pods", nc.node.Status.Capacity.Pods).Msg("converting capacity.pods")
-			}
-			if qty, err := resource.ParseQuantity(nc.node.Status.Capacity.Memory); err == nil {
-				if mem, ok := qty.AsInt64(); ok {
-					streamTags = append(streamTags, "units:bytes")
-					_ = nc.check.WriteMetricSample(
-						&buf,
-						"capacity_memory",
-						circonus.MetricTypeUint64,
-						streamTags, parentMeasurementTags,
-						uint64(mem),
-						nc.ts)
-				}
-			} else {
-				nc.log.Warn().Err(err).Str("memory", nc.node.Status.Capacity.Memory).Msg("parsing quantity capacity.memory")
-			}
-			if qty, err := resource.ParseQuantity(nc.node.Status.Capacity.EphemeralStorage); err == nil {
-				if storage, ok := qty.AsInt64(); ok {
-					streamTags = append(streamTags, "units:bytes")
-					_ = nc.check.WriteMetricSample(
-						&buf,
-						"capacity_ephemeral_storage",
-						circonus.MetricTypeUint64,
-						streamTags, parentMeasurementTags,
-						uint64(storage),
-						nc.ts)
-				}
-			} else {
-				nc.log.Warn().Err(err).Str("ephemeral_storage", nc.node.Status.Capacity.EphemeralStorage).Msg("parsing quantity capacity.ephemeral-storage")
-			}
-		}
+	// 	{ // conditions
+	// 		var streamTags []string
+	// 		streamTags = append(streamTags, parentStreamTags...)
+	// 		streamTags = append(streamTags, "status:condition")
+	// 		for _, cond := range nc.node.Status.Conditions {
+	// 			if nc.done() {
+	// 				break
+	// 			}
+	// 			_ = nc.check.WriteMetricSample(
+	// 				&buf,
+	// 				cond.Type,
+	// 				circonus.MetricTypeString,
+	// 				streamTags, parentMeasurementTags,
+	// 				cond.Message,
+	// 				nc.ts)
+	// 		}
+	// 	}
+	// 	{ // capacity and allocatable
+	// 		var streamTags []string
+	// 		streamTags = append(streamTags, parentStreamTags...)
+	// 		if v, err := strconv.Atoi(nc.node.Status.Capacity.CPU); err == nil {
+	// 			_ = nc.check.WriteMetricSample(
+	// 				&buf,
+	// 				"capacity_cpu",
+	// 				circonus.MetricTypeUint64,
+	// 				streamTags, parentMeasurementTags,
+	// 				uint64(v),
+	// 				nc.ts)
+	// 		} else {
+	// 			nc.log.Warn().Err(err).Str("cpu", nc.node.Status.Capacity.CPU).Msg("converting capacity.cpu")
+	// 		}
+	// 		if v, err := strconv.Atoi(nc.node.Status.Capacity.Pods); err == nil {
+	// 			_ = nc.check.WriteMetricSample(
+	// 				&buf,
+	// 				"capacity_pods",
+	// 				circonus.MetricTypeUint64,
+	// 				streamTags, parentMeasurementTags,
+	// 				uint64(v),
+	// 				nc.ts)
+	// 		} else {
+	// 			nc.log.Warn().Err(err).Str("pods", nc.node.Status.Capacity.Pods).Msg("converting capacity.pods")
+	// 		}
+	// 		if qty, err := resource.ParseQuantity(nc.node.Status.Capacity.Memory); err == nil {
+	// 			if mem, ok := qty.AsInt64(); ok {
+	// 				streamTags = append(streamTags, "units:bytes")
+	// 				_ = nc.check.WriteMetricSample(
+	// 					&buf,
+	// 					"capacity_memory",
+	// 					circonus.MetricTypeUint64,
+	// 					streamTags, parentMeasurementTags,
+	// 					uint64(mem),
+	// 					nc.ts)
+	// 			}
+	// 		} else {
+	// 			nc.log.Warn().Err(err).Str("memory", nc.node.Status.Capacity.Memory).Msg("parsing quantity capacity.memory")
+	// 		}
+	// 		if qty, err := resource.ParseQuantity(nc.node.Status.Capacity.EphemeralStorage); err == nil {
+	// 			if storage, ok := qty.AsInt64(); ok {
+	// 				streamTags = append(streamTags, "units:bytes")
+	// 				_ = nc.check.WriteMetricSample(
+	// 					&buf,
+	// 					"capacity_ephemeral_storage",
+	// 					circonus.MetricTypeUint64,
+	// 					streamTags, parentMeasurementTags,
+	// 					uint64(storage),
+	// 					nc.ts)
+	// 			}
+	// 		} else {
+	// 			nc.log.Warn().Err(err).Str("ephemeral_storage", nc.node.Status.Capacity.EphemeralStorage).Msg("parsing quantity capacity.ephemeral-storage")
+	// 		}
+	// 	}
 
-		if buf.Len() == 0 {
-			nc.log.Warn().Msg("no telemetry to submit")
-			return
-		}
-		if err := nc.check.SubmitStream(nc.ctx, &buf, nc.log.With().Str("type", "meta").Logger()); err != nil {
-			nc.log.Warn().Err(err).Msg("submitting metrics")
-		}
-		return
-	}
+	// 	if buf.Len() == 0 {
+	// 		nc.log.Warn().Msg("no telemetry to submit")
+	// 		return
+	// 	}
+	// 	if err := nc.check.SubmitStream(nc.ctx, &buf, nc.log.With().Str("type", "meta").Logger()); err != nil {
+	// 		nc.log.Warn().Err(err).Msg("submitting metrics")
+	// 	}
+	// 	return
+	// }
 
 	metrics := make(map[string]circonus.MetricSample)
 
@@ -482,25 +481,25 @@ func (nc *Collector) summaryNode(node *statsSummaryNode, parentStreamTags []stri
 		return
 	}
 
-	if nc.check.StreamMetrics() {
-		var buf bytes.Buffer
+	// if nc.check.StreamMetrics() {
+	// 	var buf bytes.Buffer
 
-		nc.streamCPU(&buf, &node.CPU, parentStreamTags, parentMeasurementTags)
-		nc.streamMemory(&buf, &node.Memory, parentStreamTags, parentMeasurementTags, true)
-		nc.streamNetwork(&buf, &node.Network, parentStreamTags, parentMeasurementTags)
-		nc.streamFS(&buf, &node.FS, parentStreamTags, parentMeasurementTags)
-		nc.streamRuntimeImageFS(&buf, &node.Runtime.ImageFs, parentStreamTags, parentMeasurementTags)
-		nc.streamRlimit(&buf, &node.Rlimit, parentStreamTags, parentMeasurementTags)
+	// 	nc.streamCPU(&buf, &node.CPU, parentStreamTags, parentMeasurementTags)
+	// 	nc.streamMemory(&buf, &node.Memory, parentStreamTags, parentMeasurementTags, true)
+	// 	nc.streamNetwork(&buf, &node.Network, parentStreamTags, parentMeasurementTags)
+	// 	nc.streamFS(&buf, &node.FS, parentStreamTags, parentMeasurementTags)
+	// 	nc.streamRuntimeImageFS(&buf, &node.Runtime.ImageFs, parentStreamTags, parentMeasurementTags)
+	// 	nc.streamRlimit(&buf, &node.Rlimit, parentStreamTags, parentMeasurementTags)
 
-		if buf.Len() == 0 {
-			nc.log.Warn().Msg("no telemetry to submit")
-			return
-		}
-		if err := nc.check.SubmitStream(nc.ctx, &buf, nc.log.With().Str("type", "/stats/summary").Logger()); err != nil {
-			nc.log.Warn().Err(err).Msg("submitting metrics")
-		}
-		return
-	}
+	// 	if buf.Len() == 0 {
+	// 		nc.log.Warn().Msg("no telemetry to submit")
+	// 		return
+	// 	}
+	// 	if err := nc.check.SubmitStream(nc.ctx, &buf, nc.log.With().Str("type", "/stats/summary").Logger()); err != nil {
+	// 		nc.log.Warn().Err(err).Msg("submitting metrics")
+	// 	}
+	// 	return
+	// }
 
 	metrics := make(map[string]circonus.MetricSample)
 
@@ -532,32 +531,32 @@ func (nc *Collector) summarySystemContainers(node *statsSummaryNode, parentStrea
 		return
 	}
 
-	if nc.check.StreamMetrics() {
-		var buf bytes.Buffer
+	// if nc.check.StreamMetrics() {
+	// 	var buf bytes.Buffer
 
-		for _, container := range node.SystemContainers {
-			if nc.done() {
-				break
-			}
-			var streamTags []string
-			streamTags = append(streamTags, parentStreamTags...)
-			streamTags = append(streamTags, []string{"sys_container:" + container.Name}...)
+	// 	for _, container := range node.SystemContainers {
+	// 		if nc.done() {
+	// 			break
+	// 		}
+	// 		var streamTags []string
+	// 		streamTags = append(streamTags, parentStreamTags...)
+	// 		streamTags = append(streamTags, []string{"sys_container:" + container.Name}...)
 
-			nc.streamCPU(&buf, &container.CPU, streamTags, parentMeasurementTags)
-			nc.streamMemory(&buf, &container.Memory, streamTags, parentMeasurementTags, false)
-			nc.streamRootFS(&buf, &container.RootFS, streamTags, parentMeasurementTags)
-			nc.streamLogsFS(&buf, &container.Logs, streamTags, parentMeasurementTags)
-		}
+	// 		nc.streamCPU(&buf, &container.CPU, streamTags, parentMeasurementTags)
+	// 		nc.streamMemory(&buf, &container.Memory, streamTags, parentMeasurementTags, false)
+	// 		nc.streamRootFS(&buf, &container.RootFS, streamTags, parentMeasurementTags)
+	// 		nc.streamLogsFS(&buf, &container.Logs, streamTags, parentMeasurementTags)
+	// 	}
 
-		if buf.Len() == 0 {
-			nc.log.Warn().Msg("no telemetry to submit")
-			return
-		}
-		if err := nc.check.SubmitStream(nc.ctx, &buf, nc.log.With().Str("type", "system_containers").Logger()); err != nil {
-			nc.log.Warn().Err(err).Msg("submitting metrics")
-		}
-		return
-	}
+	// 	if buf.Len() == 0 {
+	// 		nc.log.Warn().Msg("no telemetry to submit")
+	// 		return
+	// 	}
+	// 	if err := nc.check.SubmitStream(nc.ctx, &buf, nc.log.With().Str("type", "system_containers").Logger()); err != nil {
+	// 		nc.log.Warn().Err(err).Msg("submitting metrics")
+	// 	}
+	// 	return
+	// }
 
 	metrics := make(map[string]circonus.MetricSample)
 
@@ -596,72 +595,72 @@ func (nc *Collector) summaryPods(stats *statsSummary, parentStreamTags []string,
 		return
 	}
 
-	if nc.check.StreamMetrics() {
-		var buf bytes.Buffer
+	// if nc.check.StreamMetrics() {
+	// 	var buf bytes.Buffer
 
-		for _, pod := range stats.Pods {
-			if nc.done() {
-				break
-			}
-			collect, podLabels, err := nc.getPodLabels(pod.PodRef.Namespace, pod.PodRef.Name)
-			if err != nil {
-				nc.log.Warn().Err(err).Str("pod", pod.PodRef.Name).Str("ns", pod.PodRef.Namespace).Msg("fetching pod labels")
-			}
-			if !collect {
-				continue
-			}
-			var podStreamTags []string
-			podStreamTags = append(podStreamTags, parentStreamTags...)
-			podStreamTags = append(podStreamTags, podLabels...)
-			podStreamTags = append(podStreamTags, []string{
-				"pod:" + pod.PodRef.Name,
-				"namespace:" + pod.PodRef.Namespace,
-				"__rollup:false", // prevent high cardinality metrics from rolling up
-			}...)
+	// 	for _, pod := range stats.Pods {
+	// 		if nc.done() {
+	// 			break
+	// 		}
+	// 		collect, podLabels, err := nc.getPodLabels(pod.PodRef.Namespace, pod.PodRef.Name)
+	// 		if err != nil {
+	// 			nc.log.Warn().Err(err).Str("pod", pod.PodRef.Name).Str("ns", pod.PodRef.Namespace).Msg("fetching pod labels")
+	// 		}
+	// 		if !collect {
+	// 			continue
+	// 		}
+	// 		var podStreamTags []string
+	// 		podStreamTags = append(podStreamTags, parentStreamTags...)
+	// 		podStreamTags = append(podStreamTags, podLabels...)
+	// 		podStreamTags = append(podStreamTags, []string{
+	// 			"pod:" + pod.PodRef.Name,
+	// 			"namespace:" + pod.PodRef.Namespace,
+	// 			"__rollup:false", // prevent high cardinality metrics from rolling up
+	// 		}...)
 
-			nc.streamCPU(&buf, &pod.CPU, podStreamTags, parentMeasurementTags)
-			nc.streamMemory(&buf, &pod.Memory, podStreamTags, parentMeasurementTags, false)
-			nc.streamNetwork(&buf, &pod.Network, podStreamTags, parentMeasurementTags)
+	// 		nc.streamCPU(&buf, &pod.CPU, podStreamTags, parentMeasurementTags)
+	// 		nc.streamMemory(&buf, &pod.Memory, podStreamTags, parentMeasurementTags, false)
+	// 		nc.streamNetwork(&buf, &pod.Network, podStreamTags, parentMeasurementTags)
 
-			for _, volume := range pod.Volumes {
-				if nc.done() {
-					break
-				}
-				volume := volume
-				nc.streamVolume(&buf, &volume, podStreamTags, parentMeasurementTags)
-			}
+	// 		for _, volume := range pod.Volumes {
+	// 			if nc.done() {
+	// 				break
+	// 			}
+	// 			volume := volume
+	// 			nc.streamVolume(&buf, &volume, podStreamTags, parentMeasurementTags)
+	// 		}
 
-			if nc.cfg.IncludeContainers {
-				for _, container := range pod.Containers {
-					if nc.done() {
-						break
-					}
-					var streamTagList []string
-					streamTagList = append(streamTagList, podStreamTags...)
-					streamTagList = append(streamTagList, "container_name:"+container.Name)
+	// 		if nc.cfg.IncludeContainers {
+	// 			for _, container := range pod.Containers {
+	// 				if nc.done() {
+	// 					break
+	// 				}
+	// 				var streamTagList []string
+	// 				streamTagList = append(streamTagList, podStreamTags...)
+	// 				streamTagList = append(streamTagList, "container_name:"+container.Name)
 
-					nc.streamCPU(&buf, &container.CPU, streamTagList, parentMeasurementTags)
-					nc.streamMemory(&buf, &container.Memory, streamTagList, parentMeasurementTags, false)
-					if container.RootFS.CapacityBytes > 0 { // rootfs
-						nc.streamRootFS(&buf, &container.RootFS, streamTagList, parentMeasurementTags)
-					}
+	// 				nc.streamCPU(&buf, &container.CPU, streamTagList, parentMeasurementTags)
+	// 				nc.streamMemory(&buf, &container.Memory, streamTagList, parentMeasurementTags, false)
+	// 				if container.RootFS.CapacityBytes > 0 { // rootfs
+	// 					nc.streamRootFS(&buf, &container.RootFS, streamTagList, parentMeasurementTags)
+	// 				}
 
-					if container.Logs.CapacityBytes > 0 { // logs
-						nc.streamLogsFS(&buf, &container.Logs, streamTagList, parentMeasurementTags)
-					}
-				}
-			}
-		}
+	// 				if container.Logs.CapacityBytes > 0 { // logs
+	// 					nc.streamLogsFS(&buf, &container.Logs, streamTagList, parentMeasurementTags)
+	// 				}
+	// 			}
+	// 		}
+	// 	}
 
-		if buf.Len() == 0 {
-			nc.log.Warn().Msg("no telemetry to submit")
-			return
-		}
-		if err := nc.check.SubmitStream(nc.ctx, &buf, nc.log.With().Str("type", "pods").Logger()); err != nil {
-			nc.log.Warn().Err(err).Msg("submitting metrics")
-		}
-		return
-	}
+	// 	if buf.Len() == 0 {
+	// 		nc.log.Warn().Msg("no telemetry to submit")
+	// 		return
+	// 	}
+	// 	if err := nc.check.SubmitStream(nc.ctx, &buf, nc.log.With().Str("type", "pods").Logger()); err != nil {
+	// 		nc.log.Warn().Err(err).Msg("submitting metrics")
+	// 	}
+	// 	return
+	// }
 
 	metrics := make(map[string]circonus.MetricSample)
 
@@ -789,15 +788,15 @@ func (nc *Collector) nmetrics(parentStreamTags []string, parentMeasurementTags [
 		return
 	}
 
-	if nc.check.StreamMetrics() {
-		if err := promtext.StreamMetrics(nc.ctx, nc.check, nc.log, resp.Body, parentStreamTags, parentMeasurementTags, nc.ts); err != nil {
-			nc.log.Error().Err(err).Msg("parsing node metrics")
-		}
-	} else {
-		if err := promtext.QueueMetrics(nc.ctx, nc.check, nc.log, resp.Body, parentStreamTags, parentMeasurementTags, nil); err != nil {
-			nc.log.Error().Err(err).Msg("parsing node metrics")
-		}
+	// if nc.check.StreamMetrics() {
+	// 	if err := promtext.StreamMetrics(nc.ctx, nc.check, nc.log, resp.Body, parentStreamTags, parentMeasurementTags, nc.ts); err != nil {
+	// 		nc.log.Error().Err(err).Msg("parsing node metrics")
+	// 	}
+	// } else {
+	if err := promtext.QueueMetrics(nc.ctx, nc.check, nc.log, resp.Body, parentStreamTags, parentMeasurementTags, nil); err != nil {
+		nc.log.Error().Err(err).Msg("parsing node metrics")
 	}
+	// }
 }
 
 type podSpec struct {

--- a/internal/nodes/collector/collector.go
+++ b/internal/nodes/collector/collector.go
@@ -165,7 +165,7 @@ func (nc *Collector) meta(parentStreamTags []string, parentMeasurementTags []str
 					circonus.MetricTypeUint64,
 					streamTags, parentMeasurementTags,
 					uint64(v),
-					nil)
+					nc.ts)
 			} else {
 				nc.log.Warn().Err(err).Str("cpu", nc.node.Status.Capacity.CPU).Msg("converting capacity.cpu")
 			}
@@ -176,7 +176,7 @@ func (nc *Collector) meta(parentStreamTags []string, parentMeasurementTags []str
 					circonus.MetricTypeUint64,
 					streamTags, parentMeasurementTags,
 					uint64(v),
-					nil)
+					nc.ts)
 			} else {
 				nc.log.Warn().Err(err).Str("pods", nc.node.Status.Capacity.Pods).Msg("converting capacity.pods")
 			}
@@ -189,7 +189,7 @@ func (nc *Collector) meta(parentStreamTags []string, parentMeasurementTags []str
 						circonus.MetricTypeUint64,
 						streamTags, parentMeasurementTags,
 						uint64(mem),
-						nil)
+						nc.ts)
 				}
 			} else {
 				nc.log.Warn().Err(err).Str("memory", nc.node.Status.Capacity.Memory).Msg("parsing quantity capacity.memory")
@@ -203,7 +203,7 @@ func (nc *Collector) meta(parentStreamTags []string, parentMeasurementTags []str
 						circonus.MetricTypeUint64,
 						streamTags, parentMeasurementTags,
 						uint64(storage),
-						nil)
+						nc.ts)
 				}
 			} else {
 				nc.log.Warn().Err(err).Str("ephemeral_storage", nc.node.Status.Capacity.EphemeralStorage).Msg("parsing quantity capacity.ephemeral-storage")
@@ -239,7 +239,7 @@ func (nc *Collector) meta(parentStreamTags []string, parentMeasurementTags []str
 			circonus.MetricTypeString,
 			streamTags, parentMeasurementTags,
 			nc.node.Metadata.Name,
-			nil)
+			nc.ts)
 	}
 
 	{ // conditions
@@ -256,7 +256,7 @@ func (nc *Collector) meta(parentStreamTags []string, parentMeasurementTags []str
 				circonus.MetricTypeString,
 				streamTags, parentMeasurementTags,
 				cond.Message,
-				nil)
+				nc.ts)
 		}
 	}
 
@@ -270,7 +270,7 @@ func (nc *Collector) meta(parentStreamTags []string, parentMeasurementTags []str
 				circonus.MetricTypeUint64,
 				streamTags, parentMeasurementTags,
 				uint64(v),
-				nil)
+				nc.ts)
 		} else {
 			nc.log.Warn().Err(err).Str("cpu", nc.node.Status.Capacity.CPU).Msg("converting capacity.cpu")
 		}
@@ -281,7 +281,7 @@ func (nc *Collector) meta(parentStreamTags []string, parentMeasurementTags []str
 				circonus.MetricTypeUint64,
 				streamTags, parentMeasurementTags,
 				uint64(v),
-				nil)
+				nc.ts)
 		} else {
 			nc.log.Warn().Err(err).Str("pods", nc.node.Status.Capacity.Pods).Msg("converting capacity.pods")
 		}
@@ -294,7 +294,7 @@ func (nc *Collector) meta(parentStreamTags []string, parentMeasurementTags []str
 					circonus.MetricTypeUint64,
 					streamTags, parentMeasurementTags,
 					uint64(mem),
-					nil)
+					nc.ts)
 			}
 		} else {
 			nc.log.Warn().Err(err).Str("memory", nc.node.Status.Capacity.Memory).Msg("parsing quantity capacity.memory")
@@ -308,7 +308,7 @@ func (nc *Collector) meta(parentStreamTags []string, parentMeasurementTags []str
 					circonus.MetricTypeUint64,
 					streamTags, parentMeasurementTags,
 					uint64(storage),
-					nil)
+					nc.ts)
 			}
 		} else {
 			nc.log.Warn().Err(err).Str("ephemeral_storage", nc.node.Status.Capacity.EphemeralStorage).Msg("parsing quantity capacity.ephemeral-storage")

--- a/internal/nodes/collector/metrics.go
+++ b/internal/nodes/collector/metrics.go
@@ -6,8 +6,6 @@
 package collector
 
 import (
-	"io"
-
 	"github.com/circonus-labs/circonus-kubernetes-agent/internal/circonus"
 )
 
@@ -23,17 +21,17 @@ func (nc *Collector) queueCPU(dest map[string]circonus.MetricSample, stats *cpu,
 	_ = nc.check.QueueMetricSample(dest, seconds, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, stats.UsageCoreNanoSeconds, nc.ts)
 }
 
-func (nc *Collector) streamCPU(dest io.Writer, stats *cpu, parentStreamTags []string, parentMeasurementTags []string) {
-	cores := "usageNanoCores"
-	seconds := "usageCoreNanoSeconds"
+// func (nc *Collector) streamCPU(dest io.Writer, stats *cpu, parentStreamTags []string, parentMeasurementTags []string) {
+// 	cores := "usageNanoCores"
+// 	seconds := "usageCoreNanoSeconds"
 
-	var streamTags []string
-	streamTags = append(streamTags, parentStreamTags...)
-	streamTags = append(streamTags, "resource:cpu")
-	_ = nc.check.WriteMetricSample(dest, cores, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, stats.UsageNanoCores, nc.ts)
-	streamTags = append(streamTags, "units:seconds")
-	_ = nc.check.WriteMetricSample(dest, seconds, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, stats.UsageCoreNanoSeconds, nc.ts)
-}
+// 	var streamTags []string
+// 	streamTags = append(streamTags, parentStreamTags...)
+// 	streamTags = append(streamTags, "resource:cpu")
+// 	_ = nc.check.WriteMetricSample(dest, cores, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, stats.UsageNanoCores, nc.ts)
+// 	streamTags = append(streamTags, "units:seconds")
+// 	_ = nc.check.WriteMetricSample(dest, seconds, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, stats.UsageCoreNanoSeconds, nc.ts)
+// }
 
 func (nc *Collector) queueMemory(dest map[string]circonus.MetricSample, stats *memory, parentStreamTags []string, parentMeasurementTags []string, isNode bool) {
 	available := "available"
@@ -64,33 +62,33 @@ func (nc *Collector) queueMemory(dest map[string]circonus.MetricSample, stats *m
 	}
 }
 
-func (nc *Collector) streamMemory(dest io.Writer, stats *memory, parentStreamTags []string, parentMeasurementTags []string, isNode bool) {
-	available := "available"
-	used := "used"
-	workingSet := "workingSet"
-	rss := "rss"
-	pageFaults := "pageFaults"
-	majorPageFaults := "majorPageFaults"
+// func (nc *Collector) streamMemory(dest io.Writer, stats *memory, parentStreamTags []string, parentMeasurementTags []string, isNode bool) {
+// 	available := "available"
+// 	used := "used"
+// 	workingSet := "workingSet"
+// 	rss := "rss"
+// 	pageFaults := "pageFaults"
+// 	majorPageFaults := "majorPageFaults"
 
-	{ // units:bytes
-		var streamTags []string
-		streamTags = append(streamTags, parentStreamTags...)
-		streamTags = append(streamTags, []string{"resource:memory", "units:bytes"}...)
-		if isNode {
-			_ = nc.check.WriteMetricSample(dest, available, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, stats.AvailableBytes, nc.ts)
-		}
-		_ = nc.check.WriteMetricSample(dest, used, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, stats.UsageBytes, nc.ts)
-		_ = nc.check.WriteMetricSample(dest, workingSet, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, stats.WorkingSetBytes, nc.ts)
-		_ = nc.check.WriteMetricSample(dest, rss, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, stats.RSSBytes, nc.ts)
-	}
-	{ // units:faults
-		var streamTags []string
-		streamTags = append(streamTags, parentStreamTags...)
-		streamTags = append(streamTags, []string{"resource:memory", "units:faults"}...)
-		_ = nc.check.WriteMetricSample(dest, pageFaults, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, stats.PageFaults, nc.ts)
-		_ = nc.check.WriteMetricSample(dest, majorPageFaults, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, stats.MajorPageFaults, nc.ts)
-	}
-}
+// 	{ // units:bytes
+// 		var streamTags []string
+// 		streamTags = append(streamTags, parentStreamTags...)
+// 		streamTags = append(streamTags, []string{"resource:memory", "units:bytes"}...)
+// 		if isNode {
+// 			_ = nc.check.WriteMetricSample(dest, available, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, stats.AvailableBytes, nc.ts)
+// 		}
+// 		_ = nc.check.WriteMetricSample(dest, used, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, stats.UsageBytes, nc.ts)
+// 		_ = nc.check.WriteMetricSample(dest, workingSet, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, stats.WorkingSetBytes, nc.ts)
+// 		_ = nc.check.WriteMetricSample(dest, rss, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, stats.RSSBytes, nc.ts)
+// 	}
+// 	{ // units:faults
+// 		var streamTags []string
+// 		streamTags = append(streamTags, parentStreamTags...)
+// 		streamTags = append(streamTags, []string{"resource:memory", "units:faults"}...)
+// 		_ = nc.check.WriteMetricSample(dest, pageFaults, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, stats.PageFaults, nc.ts)
+// 		_ = nc.check.WriteMetricSample(dest, majorPageFaults, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, stats.MajorPageFaults, nc.ts)
+// 	}
+// }
 
 func (nc *Collector) queueNetwork(dest map[string]circonus.MetricSample, stats *network, parentStreamTags []string, parentMeasurementTags []string) {
 	receive := "rx"
@@ -129,41 +127,41 @@ func (nc *Collector) queueNetwork(dest map[string]circonus.MetricSample, stats *
 	}
 }
 
-func (nc *Collector) streamNetwork(dest io.Writer, stats *network, parentStreamTags []string, parentMeasurementTags []string) {
-	receive := "rx"
-	transmit := "tx"
+// func (nc *Collector) streamNetwork(dest io.Writer, stats *network, parentStreamTags []string, parentMeasurementTags []string) {
+// 	receive := "rx"
+// 	transmit := "tx"
 
-	{ // units:bytes
-		var streamTags []string
-		streamTags = append(streamTags, parentStreamTags...)
-		streamTags = append(streamTags, []string{"resource:network", "units:bytes"}...)
-		_ = nc.check.WriteMetricSample(dest, receive, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, stats.RxBytes, nc.ts)
-		_ = nc.check.WriteMetricSample(dest, transmit, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, stats.TxBytes, nc.ts)
-	}
-	{ // units:errors
-		var streamTags []string
-		streamTags = append(streamTags, parentStreamTags...)
-		streamTags = append(streamTags, []string{"resource:network", "units:errors"}...)
-		_ = nc.check.WriteMetricSample(dest, receive, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, stats.RxErrors, nc.ts)
-		_ = nc.check.WriteMetricSample(dest, transmit, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, stats.TxErrors, nc.ts)
-	}
-	for _, iface := range stats.Interfaces {
-		{ // units:bytes
-			var streamTags []string
-			streamTags = append(streamTags, parentStreamTags...)
-			streamTags = append(streamTags, []string{"resource:network", "units:bytes", "interface:" + iface.Name}...)
-			_ = nc.check.WriteMetricSample(dest, receive, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, iface.RxBytes, nc.ts)
-			_ = nc.check.WriteMetricSample(dest, transmit, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, iface.TxBytes, nc.ts)
-		}
-		{ // units:errors
-			var streamTags []string
-			streamTags = append(streamTags, parentStreamTags...)
-			streamTags = append(streamTags, []string{"resource:network", "units:errors", "interface:" + iface.Name}...)
-			_ = nc.check.WriteMetricSample(dest, receive, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, iface.RxErrors, nc.ts)
-			_ = nc.check.WriteMetricSample(dest, transmit, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, iface.TxErrors, nc.ts)
-		}
-	}
-}
+// 	{ // units:bytes
+// 		var streamTags []string
+// 		streamTags = append(streamTags, parentStreamTags...)
+// 		streamTags = append(streamTags, []string{"resource:network", "units:bytes"}...)
+// 		_ = nc.check.WriteMetricSample(dest, receive, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, stats.RxBytes, nc.ts)
+// 		_ = nc.check.WriteMetricSample(dest, transmit, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, stats.TxBytes, nc.ts)
+// 	}
+// 	{ // units:errors
+// 		var streamTags []string
+// 		streamTags = append(streamTags, parentStreamTags...)
+// 		streamTags = append(streamTags, []string{"resource:network", "units:errors"}...)
+// 		_ = nc.check.WriteMetricSample(dest, receive, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, stats.RxErrors, nc.ts)
+// 		_ = nc.check.WriteMetricSample(dest, transmit, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, stats.TxErrors, nc.ts)
+// 	}
+// 	for _, iface := range stats.Interfaces {
+// 		{ // units:bytes
+// 			var streamTags []string
+// 			streamTags = append(streamTags, parentStreamTags...)
+// 			streamTags = append(streamTags, []string{"resource:network", "units:bytes", "interface:" + iface.Name}...)
+// 			_ = nc.check.WriteMetricSample(dest, receive, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, iface.RxBytes, nc.ts)
+// 			_ = nc.check.WriteMetricSample(dest, transmit, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, iface.TxBytes, nc.ts)
+// 		}
+// 		{ // units:errors
+// 			var streamTags []string
+// 			streamTags = append(streamTags, parentStreamTags...)
+// 			streamTags = append(streamTags, []string{"resource:network", "units:errors", "interface:" + iface.Name}...)
+// 			_ = nc.check.WriteMetricSample(dest, receive, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, iface.RxErrors, nc.ts)
+// 			_ = nc.check.WriteMetricSample(dest, transmit, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, iface.TxErrors, nc.ts)
+// 		}
+// 	}
+// }
 
 func (nc *Collector) queueBaseFS(dest map[string]circonus.MetricSample, stats *fs, parentStreamTags []string, parentMeasurementTags []string) {
 	capacity := "capacity"
@@ -188,28 +186,28 @@ func (nc *Collector) queueBaseFS(dest map[string]circonus.MetricSample, stats *f
 	}
 }
 
-func (nc *Collector) streamBaseFS(dest io.Writer, stats *fs, parentStreamTags []string, parentMeasurementTags []string) {
-	capacity := "capacity"
-	free := "free"
-	used := "used"
+// func (nc *Collector) streamBaseFS(dest io.Writer, stats *fs, parentStreamTags []string, parentMeasurementTags []string) {
+// 	capacity := "capacity"
+// 	free := "free"
+// 	used := "used"
 
-	{ // units:bytes
-		var streamTags []string
-		streamTags = append(streamTags, parentStreamTags...)
-		streamTags = append(streamTags, "units:bytes")
-		_ = nc.check.WriteMetricSample(dest, capacity, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, stats.CapacityBytes, nc.ts)
-		_ = nc.check.WriteMetricSample(dest, free, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, stats.AvailableBytes, nc.ts)
-		_ = nc.check.WriteMetricSample(dest, used, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, stats.UsedBytes, nc.ts)
-	}
-	{ // units:inodes
-		var streamTags []string
-		streamTags = append(streamTags, parentStreamTags...)
-		streamTags = append(streamTags, "units:inodes")
-		_ = nc.check.WriteMetricSample(dest, capacity, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, stats.Inodes, nc.ts)
-		_ = nc.check.WriteMetricSample(dest, free, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, stats.InodesFree, nc.ts)
-		_ = nc.check.WriteMetricSample(dest, used, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, stats.InodesUsed, nc.ts)
-	}
-}
+// 	{ // units:bytes
+// 		var streamTags []string
+// 		streamTags = append(streamTags, parentStreamTags...)
+// 		streamTags = append(streamTags, "units:bytes")
+// 		_ = nc.check.WriteMetricSample(dest, capacity, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, stats.CapacityBytes, nc.ts)
+// 		_ = nc.check.WriteMetricSample(dest, free, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, stats.AvailableBytes, nc.ts)
+// 		_ = nc.check.WriteMetricSample(dest, used, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, stats.UsedBytes, nc.ts)
+// 	}
+// 	{ // units:inodes
+// 		var streamTags []string
+// 		streamTags = append(streamTags, parentStreamTags...)
+// 		streamTags = append(streamTags, "units:inodes")
+// 		_ = nc.check.WriteMetricSample(dest, capacity, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, stats.Inodes, nc.ts)
+// 		_ = nc.check.WriteMetricSample(dest, free, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, stats.InodesFree, nc.ts)
+// 		_ = nc.check.WriteMetricSample(dest, used, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, stats.InodesUsed, nc.ts)
+// 	}
+// }
 
 func (nc *Collector) queueFS(dest map[string]circonus.MetricSample, stats *fs, parentStreamTags []string, parentMeasurementTags []string) {
 	var baseStreamTags []string
@@ -221,15 +219,15 @@ func (nc *Collector) queueFS(dest map[string]circonus.MetricSample, stats *fs, p
 	nc.queueBaseFS(dest, stats, baseStreamTags, parentMeasurementTags)
 }
 
-func (nc *Collector) streamFS(dest io.Writer, stats *fs, parentStreamTags []string, parentMeasurementTags []string) {
-	var baseStreamTags []string
-	if len(parentStreamTags) > 0 {
-		baseStreamTags = make([]string, len(parentStreamTags))
-		copy(baseStreamTags, parentStreamTags)
-	}
-	baseStreamTags = append(baseStreamTags, "resource:fs")
-	nc.streamBaseFS(dest, stats, baseStreamTags, parentMeasurementTags)
-}
+// func (nc *Collector) streamFS(dest io.Writer, stats *fs, parentStreamTags []string, parentMeasurementTags []string) {
+// 	var baseStreamTags []string
+// 	if len(parentStreamTags) > 0 {
+// 		baseStreamTags = make([]string, len(parentStreamTags))
+// 		copy(baseStreamTags, parentStreamTags)
+// 	}
+// 	baseStreamTags = append(baseStreamTags, "resource:fs")
+// 	nc.streamBaseFS(dest, stats, baseStreamTags, parentMeasurementTags)
+// }
 
 func (nc *Collector) queueRuntimeImageFS(dest map[string]circonus.MetricSample, stats *fs, parentStreamTags []string, parentMeasurementTags []string) {
 	var baseStreamTags []string
@@ -241,15 +239,15 @@ func (nc *Collector) queueRuntimeImageFS(dest map[string]circonus.MetricSample, 
 	nc.queueBaseFS(dest, stats, baseStreamTags, parentMeasurementTags)
 }
 
-func (nc *Collector) streamRuntimeImageFS(dest io.Writer, stats *fs, parentStreamTags []string, parentMeasurementTags []string) {
-	var baseStreamTags []string
-	if len(parentStreamTags) > 0 {
-		baseStreamTags = make([]string, len(parentStreamTags))
-		copy(baseStreamTags, parentStreamTags)
-	}
-	baseStreamTags = append(baseStreamTags, "resource:runtime_image_fs")
-	nc.streamBaseFS(dest, stats, baseStreamTags, parentMeasurementTags)
-}
+// func (nc *Collector) streamRuntimeImageFS(dest io.Writer, stats *fs, parentStreamTags []string, parentMeasurementTags []string) {
+// 	var baseStreamTags []string
+// 	if len(parentStreamTags) > 0 {
+// 		baseStreamTags = make([]string, len(parentStreamTags))
+// 		copy(baseStreamTags, parentStreamTags)
+// 	}
+// 	baseStreamTags = append(baseStreamTags, "resource:runtime_image_fs")
+// 	nc.streamBaseFS(dest, stats, baseStreamTags, parentMeasurementTags)
+// }
 
 func (nc *Collector) queueRootFS(dest map[string]circonus.MetricSample, stats *fs, parentStreamTags []string, parentMeasurementTags []string) {
 	var baseStreamTags []string
@@ -261,15 +259,15 @@ func (nc *Collector) queueRootFS(dest map[string]circonus.MetricSample, stats *f
 	nc.queueBaseFS(dest, stats, baseStreamTags, parentMeasurementTags)
 }
 
-func (nc *Collector) streamRootFS(dest io.Writer, stats *fs, parentStreamTags []string, parentMeasurementTags []string) {
-	var baseStreamTags []string
-	if len(parentStreamTags) > 0 {
-		baseStreamTags = make([]string, len(parentStreamTags))
-		copy(baseStreamTags, parentStreamTags)
-	}
-	baseStreamTags = append(baseStreamTags, "resource:root_fs")
-	nc.streamBaseFS(dest, stats, baseStreamTags, parentMeasurementTags)
-}
+// func (nc *Collector) streamRootFS(dest io.Writer, stats *fs, parentStreamTags []string, parentMeasurementTags []string) {
+// 	var baseStreamTags []string
+// 	if len(parentStreamTags) > 0 {
+// 		baseStreamTags = make([]string, len(parentStreamTags))
+// 		copy(baseStreamTags, parentStreamTags)
+// 	}
+// 	baseStreamTags = append(baseStreamTags, "resource:root_fs")
+// 	nc.streamBaseFS(dest, stats, baseStreamTags, parentMeasurementTags)
+// }
 
 func (nc *Collector) queueLogsFS(dest map[string]circonus.MetricSample, stats *fs, parentStreamTags []string, parentMeasurementTags []string) {
 	var baseStreamTags []string
@@ -281,15 +279,15 @@ func (nc *Collector) queueLogsFS(dest map[string]circonus.MetricSample, stats *f
 	nc.queueBaseFS(dest, stats, baseStreamTags, parentMeasurementTags)
 }
 
-func (nc *Collector) streamLogsFS(dest io.Writer, stats *fs, parentStreamTags []string, parentMeasurementTags []string) {
-	var baseStreamTags []string
-	if len(parentStreamTags) > 0 {
-		baseStreamTags = make([]string, len(parentStreamTags))
-		copy(baseStreamTags, parentStreamTags)
-	}
-	baseStreamTags = append(baseStreamTags, "resource:logs_fs")
-	nc.streamBaseFS(dest, stats, baseStreamTags, parentMeasurementTags)
-}
+// func (nc *Collector) streamLogsFS(dest io.Writer, stats *fs, parentStreamTags []string, parentMeasurementTags []string) {
+// 	var baseStreamTags []string
+// 	if len(parentStreamTags) > 0 {
+// 		baseStreamTags = make([]string, len(parentStreamTags))
+// 		copy(baseStreamTags, parentStreamTags)
+// 	}
+// 	baseStreamTags = append(baseStreamTags, "resource:logs_fs")
+// 	nc.streamBaseFS(dest, stats, baseStreamTags, parentMeasurementTags)
+// }
 
 func (nc *Collector) queueVolume(dest map[string]circonus.MetricSample, stats *volume, parentStreamTags []string, parentMeasurementTags []string) {
 	var baseStreamTags []string
@@ -301,15 +299,15 @@ func (nc *Collector) queueVolume(dest map[string]circonus.MetricSample, stats *v
 	nc.queueBaseFS(dest, &stats.fs, baseStreamTags, parentMeasurementTags)
 }
 
-func (nc *Collector) streamVolume(dest io.Writer, stats *volume, parentStreamTags []string, parentMeasurementTags []string) {
-	var baseStreamTags []string
-	if len(parentStreamTags) > 0 {
-		baseStreamTags = make([]string, len(parentStreamTags))
-		copy(baseStreamTags, parentStreamTags)
-	}
-	baseStreamTags = append(baseStreamTags, "volume_name:"+stats.Name)
-	nc.streamBaseFS(dest, &stats.fs, baseStreamTags, parentMeasurementTags)
-}
+// func (nc *Collector) streamVolume(dest io.Writer, stats *volume, parentStreamTags []string, parentMeasurementTags []string) {
+// 	var baseStreamTags []string
+// 	if len(parentStreamTags) > 0 {
+// 		baseStreamTags = make([]string, len(parentStreamTags))
+// 		copy(baseStreamTags, parentStreamTags)
+// 	}
+// 	baseStreamTags = append(baseStreamTags, "volume_name:"+stats.Name)
+// 	nc.streamBaseFS(dest, &stats.fs, baseStreamTags, parentMeasurementTags)
+// }
 
 func (nc *Collector) queueRlimit(dest map[string]circonus.MetricSample, stats *rlimit, parentStreamTags []string, parentMeasurementTags []string) {
 	maxPID := "maxPID"
@@ -323,14 +321,14 @@ func (nc *Collector) queueRlimit(dest map[string]circonus.MetricSample, stats *r
 	_ = nc.check.QueueMetricSample(dest, curProc, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, stats.CurProc, nc.ts)
 }
 
-func (nc *Collector) streamRlimit(dest io.Writer, stats *rlimit, parentStreamTags []string, parentMeasurementTags []string) {
-	maxPID := "maxPID"
-	curProc := "curProc"
+// func (nc *Collector) streamRlimit(dest io.Writer, stats *rlimit, parentStreamTags []string, parentMeasurementTags []string) {
+// 	maxPID := "maxPID"
+// 	curProc := "curProc"
 
-	// units:procs
-	var streamTags []string
-	streamTags = append(streamTags, parentStreamTags...)
-	streamTags = append(streamTags, []string{"resource:rlimit", "units:procs"}...)
-	_ = nc.check.WriteMetricSample(dest, maxPID, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, stats.MaxPID, nc.ts)
-	_ = nc.check.WriteMetricSample(dest, curProc, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, stats.CurProc, nc.ts)
-}
+// 	// units:procs
+// 	var streamTags []string
+// 	streamTags = append(streamTags, parentStreamTags...)
+// 	streamTags = append(streamTags, []string{"resource:rlimit", "units:procs"}...)
+// 	_ = nc.check.WriteMetricSample(dest, maxPID, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, stats.MaxPID, nc.ts)
+// 	_ = nc.check.WriteMetricSample(dest, curProc, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, stats.CurProc, nc.ts)
+// }

--- a/internal/nodes/collector/metrics.go
+++ b/internal/nodes/collector/metrics.go
@@ -18,9 +18,9 @@ func (nc *Collector) queueCPU(dest map[string]circonus.MetricSample, stats *cpu,
 	var streamTags []string
 	streamTags = append(streamTags, parentStreamTags...)
 	streamTags = append(streamTags, "resource:cpu")
-	_ = nc.check.QueueMetricSample(dest, cores, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, stats.UsageNanoCores, nil)
+	_ = nc.check.QueueMetricSample(dest, cores, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, stats.UsageNanoCores, nc.ts)
 	streamTags = append(streamTags, "units:seconds")
-	_ = nc.check.QueueMetricSample(dest, seconds, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, stats.UsageCoreNanoSeconds, nil)
+	_ = nc.check.QueueMetricSample(dest, seconds, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, stats.UsageCoreNanoSeconds, nc.ts)
 }
 
 func (nc *Collector) streamCPU(dest io.Writer, stats *cpu, parentStreamTags []string, parentMeasurementTags []string) {
@@ -49,18 +49,18 @@ func (nc *Collector) queueMemory(dest map[string]circonus.MetricSample, stats *m
 		streamTags = append(streamTags, []string{"resource:memory", "units:bytes"}...)
 		if isNode {
 			// pods don't have 'available'
-			_ = nc.check.QueueMetricSample(dest, available, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, stats.AvailableBytes, nil)
+			_ = nc.check.QueueMetricSample(dest, available, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, stats.AvailableBytes, nc.ts)
 		}
-		_ = nc.check.QueueMetricSample(dest, used, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, stats.UsageBytes, nil)
-		_ = nc.check.QueueMetricSample(dest, workingSet, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, stats.WorkingSetBytes, nil)
-		_ = nc.check.QueueMetricSample(dest, rss, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, stats.RSSBytes, nil)
+		_ = nc.check.QueueMetricSample(dest, used, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, stats.UsageBytes, nc.ts)
+		_ = nc.check.QueueMetricSample(dest, workingSet, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, stats.WorkingSetBytes, nc.ts)
+		_ = nc.check.QueueMetricSample(dest, rss, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, stats.RSSBytes, nc.ts)
 	}
 	{ // units:faults
 		var streamTags []string
 		streamTags = append(streamTags, parentStreamTags...)
 		streamTags = append(streamTags, []string{"resource:memory", "units:faults"}...)
-		_ = nc.check.QueueMetricSample(dest, pageFaults, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, stats.PageFaults, nil)
-		_ = nc.check.QueueMetricSample(dest, majorPageFaults, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, stats.MajorPageFaults, nil)
+		_ = nc.check.QueueMetricSample(dest, pageFaults, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, stats.PageFaults, nc.ts)
+		_ = nc.check.QueueMetricSample(dest, majorPageFaults, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, stats.MajorPageFaults, nc.ts)
 	}
 }
 
@@ -100,15 +100,15 @@ func (nc *Collector) queueNetwork(dest map[string]circonus.MetricSample, stats *
 		var streamTags []string
 		streamTags = append(streamTags, parentStreamTags...)
 		streamTags = append(streamTags, []string{"resource:network", "units:bytes"}...)
-		_ = nc.check.QueueMetricSample(dest, receive, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, stats.RxBytes, nil)
-		_ = nc.check.QueueMetricSample(dest, transmit, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, stats.TxBytes, nil)
+		_ = nc.check.QueueMetricSample(dest, receive, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, stats.RxBytes, nc.ts)
+		_ = nc.check.QueueMetricSample(dest, transmit, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, stats.TxBytes, nc.ts)
 	}
 	{ // units:errors
 		var streamTags []string
 		streamTags = append(streamTags, parentStreamTags...)
 		streamTags = append(streamTags, []string{"resource:network", "units:errors"}...)
-		_ = nc.check.QueueMetricSample(dest, receive, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, stats.RxErrors, nil)
-		_ = nc.check.QueueMetricSample(dest, transmit, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, stats.TxErrors, nil)
+		_ = nc.check.QueueMetricSample(dest, receive, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, stats.RxErrors, nc.ts)
+		_ = nc.check.QueueMetricSample(dest, transmit, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, stats.TxErrors, nc.ts)
 	}
 
 	for _, iface := range stats.Interfaces {
@@ -116,15 +116,15 @@ func (nc *Collector) queueNetwork(dest map[string]circonus.MetricSample, stats *
 			var streamTags []string
 			streamTags = append(streamTags, parentStreamTags...)
 			streamTags = append(streamTags, []string{"resource:network", "units:bytes", "interface:" + iface.Name}...)
-			_ = nc.check.QueueMetricSample(dest, receive, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, iface.RxBytes, nil)
-			_ = nc.check.QueueMetricSample(dest, transmit, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, iface.TxBytes, nil)
+			_ = nc.check.QueueMetricSample(dest, receive, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, iface.RxBytes, nc.ts)
+			_ = nc.check.QueueMetricSample(dest, transmit, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, iface.TxBytes, nc.ts)
 		}
 		{ // units:errors
 			var streamTags []string
 			streamTags = append(streamTags, parentStreamTags...)
 			streamTags = append(streamTags, []string{"resource:network", "units:errors", "interface:" + iface.Name}...)
-			_ = nc.check.QueueMetricSample(dest, receive, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, iface.RxErrors, nil)
-			_ = nc.check.QueueMetricSample(dest, transmit, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, iface.TxErrors, nil)
+			_ = nc.check.QueueMetricSample(dest, receive, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, iface.RxErrors, nc.ts)
+			_ = nc.check.QueueMetricSample(dest, transmit, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, iface.TxErrors, nc.ts)
 		}
 	}
 }
@@ -152,15 +152,15 @@ func (nc *Collector) streamNetwork(dest io.Writer, stats *network, parentStreamT
 			var streamTags []string
 			streamTags = append(streamTags, parentStreamTags...)
 			streamTags = append(streamTags, []string{"resource:network", "units:bytes", "interface:" + iface.Name}...)
-			_ = nc.check.WriteMetricSample(dest, receive, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, iface.RxBytes, nil)
-			_ = nc.check.WriteMetricSample(dest, transmit, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, iface.TxBytes, nil)
+			_ = nc.check.WriteMetricSample(dest, receive, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, iface.RxBytes, nc.ts)
+			_ = nc.check.WriteMetricSample(dest, transmit, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, iface.TxBytes, nc.ts)
 		}
 		{ // units:errors
 			var streamTags []string
 			streamTags = append(streamTags, parentStreamTags...)
 			streamTags = append(streamTags, []string{"resource:network", "units:errors", "interface:" + iface.Name}...)
-			_ = nc.check.WriteMetricSample(dest, receive, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, iface.RxErrors, nil)
-			_ = nc.check.WriteMetricSample(dest, transmit, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, iface.TxErrors, nil)
+			_ = nc.check.WriteMetricSample(dest, receive, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, iface.RxErrors, nc.ts)
+			_ = nc.check.WriteMetricSample(dest, transmit, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, iface.TxErrors, nc.ts)
 		}
 	}
 }
@@ -174,17 +174,17 @@ func (nc *Collector) queueBaseFS(dest map[string]circonus.MetricSample, stats *f
 		var streamTags []string
 		streamTags = append(streamTags, parentStreamTags...)
 		streamTags = append(streamTags, "units:bytes")
-		_ = nc.check.QueueMetricSample(dest, capacity, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, stats.CapacityBytes, nil)
-		_ = nc.check.QueueMetricSample(dest, free, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, stats.AvailableBytes, nil)
-		_ = nc.check.QueueMetricSample(dest, used, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, stats.UsedBytes, nil)
+		_ = nc.check.QueueMetricSample(dest, capacity, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, stats.CapacityBytes, nc.ts)
+		_ = nc.check.QueueMetricSample(dest, free, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, stats.AvailableBytes, nc.ts)
+		_ = nc.check.QueueMetricSample(dest, used, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, stats.UsedBytes, nc.ts)
 	}
 	{ // units:inodes
 		var streamTags []string
 		streamTags = append(streamTags, parentStreamTags...)
 		streamTags = append(streamTags, "units:inodes")
-		_ = nc.check.QueueMetricSample(dest, capacity, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, stats.Inodes, nil)
-		_ = nc.check.QueueMetricSample(dest, free, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, stats.InodesFree, nil)
-		_ = nc.check.QueueMetricSample(dest, used, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, stats.InodesUsed, nil)
+		_ = nc.check.QueueMetricSample(dest, capacity, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, stats.Inodes, nc.ts)
+		_ = nc.check.QueueMetricSample(dest, free, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, stats.InodesFree, nc.ts)
+		_ = nc.check.QueueMetricSample(dest, used, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, stats.InodesUsed, nc.ts)
 	}
 }
 
@@ -319,8 +319,8 @@ func (nc *Collector) queueRlimit(dest map[string]circonus.MetricSample, stats *r
 	var streamTags []string
 	streamTags = append(streamTags, parentStreamTags...)
 	streamTags = append(streamTags, []string{"resource:rlimit", "units:procs"}...)
-	_ = nc.check.QueueMetricSample(dest, maxPID, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, stats.MaxPID, nil)
-	_ = nc.check.QueueMetricSample(dest, curProc, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, stats.CurProc, nil)
+	_ = nc.check.QueueMetricSample(dest, maxPID, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, stats.MaxPID, nc.ts)
+	_ = nc.check.QueueMetricSample(dest, curProc, circonus.MetricTypeUint64, streamTags, parentMeasurementTags, stats.CurProc, nc.ts)
 }
 
 func (nc *Collector) streamRlimit(dest io.Writer, stats *rlimit, parentStreamTags []string, parentMeasurementTags []string) {

--- a/internal/promtext/promtext.go
+++ b/internal/promtext/promtext.go
@@ -7,7 +7,6 @@
 package promtext
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -181,168 +180,168 @@ func QueueMetrics(
 	return nil
 }
 
-// StreamMetrics is a generic function to digest prometheus text format metrics and
-// emit circonus formatted metrics.
-// Formats supported: https://prometheus.io/docs/instrumenting/exposition_formats/
-func StreamMetrics(
-	ctx context.Context,
-	check *circonus.Check,
-	logger zerolog.Logger,
-	data io.Reader,
-	parentStreamTags []string,
-	parentMeasurementTags []string,
-	ts *time.Time) error {
+// // StreamMetrics is a generic function to digest prometheus text format metrics and
+// // emit circonus formatted metrics.
+// // Formats supported: https://prometheus.io/docs/instrumenting/exposition_formats/
+// func StreamMetrics(
+// 	ctx context.Context,
+// 	check *circonus.Check,
+// 	logger zerolog.Logger,
+// 	data io.Reader,
+// 	parentStreamTags []string,
+// 	parentMeasurementTags []string,
+// 	ts *time.Time) error {
 
-	var baseStreamTags []string
-	if len(parentStreamTags) > 0 {
-		baseStreamTags = make([]string, len(parentStreamTags))
-		copy(baseStreamTags, parentStreamTags)
-	}
+// 	var baseStreamTags []string
+// 	if len(parentStreamTags) > 0 {
+// 		baseStreamTags = make([]string, len(parentStreamTags))
+// 		copy(baseStreamTags, parentStreamTags)
+// 	}
 
-	var parser expfmt.TextParser
+// 	var parser expfmt.TextParser
 
-	metricFamilies, err := parser.TextToMetricFamilies(data)
-	if err != nil {
-		return err
-	}
+// 	metricFamilies, err := parser.TextToMetricFamilies(data)
+// 	if err != nil {
+// 		return err
+// 	}
 
-	var buf bytes.Buffer
-	metricsQueued := 0
-	maxMetrics := check.MaxMetricBucketSize()
+// 	var buf bytes.Buffer
+// 	metricsQueued := 0
+// 	maxMetrics := check.MaxMetricBucketSize()
 
-	for mn, mf := range metricFamilies {
-		if done(ctx) {
-			return nil
-		}
-		for _, m := range mf.Metric {
-			if done(ctx) {
-				return nil
-			}
-			if maxMetrics > 0 && metricsQueued >= maxMetrics {
-				if err := check.SubmitStream(ctx, &buf, logger); err != nil {
-					logger.Warn().Err(err).Msg("submitting metrics")
-				}
-				buf.Reset()
-			}
-			metricName := mn
-			streamTags := getLabels(m)
-			streamTags = append(streamTags, baseStreamTags...)
-			switch mf.GetType() {
-			case dto.MetricType_SUMMARY:
-				_ = check.WriteMetricSample(
-					&buf, metricName+"_count",
-					circonus.MetricTypeUint64,
-					streamTags, parentMeasurementTags,
-					m.GetSummary().GetSampleCount(), ts)
-				metricsQueued++
-				_ = check.WriteMetricSample(
-					&buf, metricName+"_sum",
-					circonus.MetricTypeFloat64,
-					streamTags, parentMeasurementTags,
-					m.GetSummary().GetSampleSum(), ts)
-				metricsQueued++
-				for qn, qv := range getQuantiles(m) {
-					var qtags []string
-					qtags = append(qtags, streamTags...)
-					qtags = append(qtags, "quantile:"+qn)
-					_ = check.WriteMetricSample(
-						&buf, metricName,
-						circonus.MetricTypeFloat64,
-						qtags, parentMeasurementTags,
-						qv, ts)
-					metricsQueued++
-				}
-			case dto.MetricType_HISTOGRAM:
-				_ = check.WriteMetricSample(
-					&buf, metricName+"_count",
-					circonus.MetricTypeUint64,
-					streamTags, parentMeasurementTags,
-					m.GetHistogram().GetSampleCount(), ts)
-				metricsQueued++
-				_ = check.WriteMetricSample(
-					&buf, metricName+"_sum",
-					circonus.MetricTypeFloat64,
-					streamTags, parentMeasurementTags,
-					m.GetHistogram().GetSampleSum(), ts)
-				metricsQueued++
-				if emitHistogramBuckets {
-					if circCumulativeHistogram {
-						var htags []string
-						htags = append(htags, streamTags...)
-						histo := promHistoBucketsToCircHisto(m)
-						if len(histo) > 0 {
-							_ = check.WriteMetricSample(
-								&buf, metricName,
-								circonus.MetricTypeCumulativeHistogram,
-								htags, parentMeasurementTags,
-								strings.Join(histo, ","), ts)
-							metricsQueued++
-						}
-					} else {
-						for bn, bv := range getBuckets(m) {
-							var htags []string
-							htags = append(htags, streamTags...)
-							htags = append(htags, "bucket:"+bn)
-							_ = check.WriteMetricSample(
-								&buf, metricName,
-								circonus.MetricTypeUint64,
-								htags, parentMeasurementTags,
-								bv, ts)
-							metricsQueued++
-						}
-					}
-				}
-			default:
-				switch {
-				case m.Gauge != nil:
-					if m.GetGauge().Value != nil {
-						_ = check.WriteMetricSample(
-							&buf, metricName,
-							circonus.MetricTypeFloat64,
-							streamTags, parentMeasurementTags,
-							*m.GetGauge().Value, ts)
-						metricsQueued++
-					}
-				case m.Counter != nil:
-					if m.GetCounter().Value != nil {
-						_ = check.WriteMetricSample(
-							&buf, metricName,
-							circonus.MetricTypeFloat64,
-							streamTags, parentMeasurementTags,
-							*m.GetCounter().Value, ts)
-						metricsQueued++
-					}
-				case m.Untyped != nil:
-					if m.GetUntyped().Value != nil {
-						if *m.GetUntyped().Value == math.Inf(+1) {
-							logger.Warn().
-								Str("metric", metricName).
-								Str("type", mf.GetType().String()).
-								Str("value", (*m).GetUntyped().String()).
-								Msg("cannot coerce +Inf to uint64")
-							continue
-						}
-						_ = check.WriteMetricSample(
-							&buf, metricName,
-							circonus.MetricTypeFloat64,
-							streamTags, parentMeasurementTags,
-							*m.GetUntyped().Value, ts)
-						metricsQueued++
-					}
-				}
-			}
-		}
-	}
-	// send any remaining metrics
-	if buf.Len() > 0 {
-		if err := check.SubmitStream(ctx, &buf, logger); err != nil {
-			logger.Warn().Err(err).Msg("submitting metrics")
-		}
+// 	for mn, mf := range metricFamilies {
+// 		if done(ctx) {
+// 			return nil
+// 		}
+// 		for _, m := range mf.Metric {
+// 			if done(ctx) {
+// 				return nil
+// 			}
+// 			if maxMetrics > 0 && metricsQueued >= maxMetrics {
+// 				if err := check.SubmitStream(ctx, &buf, logger); err != nil {
+// 					logger.Warn().Err(err).Msg("submitting metrics")
+// 				}
+// 				buf.Reset()
+// 			}
+// 			metricName := mn
+// 			streamTags := getLabels(m)
+// 			streamTags = append(streamTags, baseStreamTags...)
+// 			switch mf.GetType() {
+// 			case dto.MetricType_SUMMARY:
+// 				_ = check.WriteMetricSample(
+// 					&buf, metricName+"_count",
+// 					circonus.MetricTypeUint64,
+// 					streamTags, parentMeasurementTags,
+// 					m.GetSummary().GetSampleCount(), ts)
+// 				metricsQueued++
+// 				_ = check.WriteMetricSample(
+// 					&buf, metricName+"_sum",
+// 					circonus.MetricTypeFloat64,
+// 					streamTags, parentMeasurementTags,
+// 					m.GetSummary().GetSampleSum(), ts)
+// 				metricsQueued++
+// 				for qn, qv := range getQuantiles(m) {
+// 					var qtags []string
+// 					qtags = append(qtags, streamTags...)
+// 					qtags = append(qtags, "quantile:"+qn)
+// 					_ = check.WriteMetricSample(
+// 						&buf, metricName,
+// 						circonus.MetricTypeFloat64,
+// 						qtags, parentMeasurementTags,
+// 						qv, ts)
+// 					metricsQueued++
+// 				}
+// 			case dto.MetricType_HISTOGRAM:
+// 				_ = check.WriteMetricSample(
+// 					&buf, metricName+"_count",
+// 					circonus.MetricTypeUint64,
+// 					streamTags, parentMeasurementTags,
+// 					m.GetHistogram().GetSampleCount(), ts)
+// 				metricsQueued++
+// 				_ = check.WriteMetricSample(
+// 					&buf, metricName+"_sum",
+// 					circonus.MetricTypeFloat64,
+// 					streamTags, parentMeasurementTags,
+// 					m.GetHistogram().GetSampleSum(), ts)
+// 				metricsQueued++
+// 				if emitHistogramBuckets {
+// 					if circCumulativeHistogram {
+// 						var htags []string
+// 						htags = append(htags, streamTags...)
+// 						histo := promHistoBucketsToCircHisto(m)
+// 						if len(histo) > 0 {
+// 							_ = check.WriteMetricSample(
+// 								&buf, metricName,
+// 								circonus.MetricTypeCumulativeHistogram,
+// 								htags, parentMeasurementTags,
+// 								strings.Join(histo, ","), ts)
+// 							metricsQueued++
+// 						}
+// 					} else {
+// 						for bn, bv := range getBuckets(m) {
+// 							var htags []string
+// 							htags = append(htags, streamTags...)
+// 							htags = append(htags, "bucket:"+bn)
+// 							_ = check.WriteMetricSample(
+// 								&buf, metricName,
+// 								circonus.MetricTypeUint64,
+// 								htags, parentMeasurementTags,
+// 								bv, ts)
+// 							metricsQueued++
+// 						}
+// 					}
+// 				}
+// 			default:
+// 				switch {
+// 				case m.Gauge != nil:
+// 					if m.GetGauge().Value != nil {
+// 						_ = check.WriteMetricSample(
+// 							&buf, metricName,
+// 							circonus.MetricTypeFloat64,
+// 							streamTags, parentMeasurementTags,
+// 							*m.GetGauge().Value, ts)
+// 						metricsQueued++
+// 					}
+// 				case m.Counter != nil:
+// 					if m.GetCounter().Value != nil {
+// 						_ = check.WriteMetricSample(
+// 							&buf, metricName,
+// 							circonus.MetricTypeFloat64,
+// 							streamTags, parentMeasurementTags,
+// 							*m.GetCounter().Value, ts)
+// 						metricsQueued++
+// 					}
+// 				case m.Untyped != nil:
+// 					if m.GetUntyped().Value != nil {
+// 						if *m.GetUntyped().Value == math.Inf(+1) {
+// 							logger.Warn().
+// 								Str("metric", metricName).
+// 								Str("type", mf.GetType().String()).
+// 								Str("value", (*m).GetUntyped().String()).
+// 								Msg("cannot coerce +Inf to uint64")
+// 							continue
+// 						}
+// 						_ = check.WriteMetricSample(
+// 							&buf, metricName,
+// 							circonus.MetricTypeFloat64,
+// 							streamTags, parentMeasurementTags,
+// 							*m.GetUntyped().Value, ts)
+// 						metricsQueued++
+// 					}
+// 				}
+// 			}
+// 		}
+// 	}
+// 	// send any remaining metrics
+// 	if buf.Len() > 0 {
+// 		if err := check.SubmitStream(ctx, &buf, logger); err != nil {
+// 			logger.Warn().Err(err).Msg("submitting metrics")
+// 		}
 
-	}
+// 	}
 
-	return nil
-}
+// 	return nil
+// }
 
 func getLabels(m *dto.Metric) []string {
 	labels := []string{}

--- a/internal/promtext/promtext.go
+++ b/internal/promtext/promtext.go
@@ -94,7 +94,7 @@ func QueueMetrics(
 						metrics, metricName,
 						circonus.MetricTypeFloat64,
 						qtags, parentMeasurementTags,
-						qv, nil)
+						qv, ts)
 				}
 			case dto.MetricType_HISTOGRAM:
 				_ = check.QueueMetricSample(
@@ -249,7 +249,7 @@ func StreamMetrics(
 						&buf, metricName,
 						circonus.MetricTypeFloat64,
 						qtags, parentMeasurementTags,
-						qv, nil)
+						qv, ts)
 					metricsQueued++
 				}
 			case dto.MetricType_HISTOGRAM:


### PR DESCRIPTION
* add: option `--serial-submissions` to disable concurrent submissions
* upd: default to concurrent submissions w/timestamp metrics
* upd: deprecate streaming metrics as an option
* fix: use metric queue for events
* fix: ensure all metrics have timestamp, address drift on retries
* fix: `/health` output
