### PR TITLE
v0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# v0.6.2
+
+* add: optional, metric collection for kube-dns
+* upd: default check.target to cluster.name if target is unset
+* add: error if neither metric or telemetry ports found in ksm service definition
+* add: warn if metric port not found in ksm service definition
+* add: warn if telemetry port not found in ksm service definition
+* add: debug message for ksm urls being used
+
 # v0.6.1
 
 * add: `__rollup:false` stream tag to remaining high cardinality metrics

--- a/cmd/args_circonus.go
+++ b/cmd/args_circonus.go
@@ -327,27 +327,6 @@ func init() {
 		viper.SetDefault(key, defaultValue)
 	}
 
-	// {
-	// 	const (
-	// 		key          = keys.StreamMetrics
-	// 		longOpt      = "stream-metrics"
-	// 		envVar       = release.ENVPREFIX + "_STREAM_METRICS"
-	// 		description  = "Stream metrics (applicable when using _ts)"
-	// 		defaultValue = defaults.StreamMetrics
-	// 	)
-
-	// 	rootCmd.PersistentFlags().Bool(longOpt, defaultValue, envDescription(description, envVar))
-	// 	flag := rootCmd.PersistentFlags().Lookup(longOpt)
-	// 	flag.Hidden = true
-	// 	if err := viper.BindPFlag(key, flag); err != nil {
-	// 		bindFlagError(longOpt, err)
-	// 	}
-	// 	if err := viper.BindEnv(key, envVar); err != nil {
-	// 		bindEnvError(envVar, err)
-	// 	}
-	// 	viper.SetDefault(key, defaultValue)
-	// }
-
 	{
 		const (
 			key          = keys.NoGZIP
@@ -369,26 +348,26 @@ func init() {
 		viper.SetDefault(key, defaultValue)
 	}
 
-	{
-		const (
-			key          = keys.DebugSubmissions
-			longOpt      = "debug-submissions"
-			envVar       = release.ENVPREFIX + "_DEBUG_SUBMISSIONS"
-			description  = "Enable submission debugging (dump request w/payload to stdout)"
-			defaultValue = defaults.DebugSubmissions
-		)
+	// {
+	// 	const (
+	// 		key          = keys.DebugSubmissions
+	// 		longOpt      = "debug-submissions"
+	// 		envVar       = release.ENVPREFIX + "_DEBUG_SUBMISSIONS"
+	// 		description  = "Enable submission debugging (dump request w/payload to stdout)"
+	// 		defaultValue = defaults.DebugSubmissions
+	// 	)
 
-		rootCmd.PersistentFlags().Bool(longOpt, defaultValue, envDescription(description, envVar))
-		flag := rootCmd.PersistentFlags().Lookup(longOpt)
-		flag.Hidden = true
-		if err := viper.BindPFlag(key, flag); err != nil {
-			bindFlagError(longOpt, err)
-		}
-		if err := viper.BindEnv(key, envVar); err != nil {
-			bindEnvError(envVar, err)
-		}
-		viper.SetDefault(key, defaultValue)
-	}
+	// 	rootCmd.PersistentFlags().Bool(longOpt, defaultValue, envDescription(description, envVar))
+	// 	flag := rootCmd.PersistentFlags().Lookup(longOpt)
+	// 	flag.Hidden = true
+	// 	if err := viper.BindPFlag(key, flag); err != nil {
+	// 		bindFlagError(longOpt, err)
+	// 	}
+	// 	if err := viper.BindEnv(key, envVar); err != nil {
+	// 		bindEnvError(envVar, err)
+	// 	}
+	// 	viper.SetDefault(key, defaultValue)
+	// }
 	// {
 	// 	const (
 	// 		key          = keys.ConcurrentSubmissions

--- a/cmd/args_kubernetes.go
+++ b/cmd/args_kubernetes.go
@@ -285,6 +285,25 @@ func init() {
 
 	{
 		const (
+			key          = keys.K8SEnableKubeDNSMetrics
+			longOpt      = "k8s-enable-kube-dns-metrics"
+			envVar       = release.ENVPREFIX + "_K8S_ENABLE_KUBE_DNS_METRICS"
+			description  = "Kubernetes enable collection of kube dns metrics"
+			defaultValue = defaults.K8SEnableKubeDNSMetrics
+		)
+
+		rootCmd.PersistentFlags().Bool(longOpt, defaultValue, envDescription(description, envVar))
+		if err := viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)); err != nil {
+			bindFlagError(longOpt, err)
+		}
+		if err := viper.BindEnv(key, envVar); err != nil {
+			bindEnvError(envVar, err)
+		}
+		viper.SetDefault(key, defaultValue)
+	}
+
+	{
+		const (
 			key          = keys.K8SIncludePods
 			longOpt      = "k8s-include-pods"
 			envVar       = release.ENVPREFIX + "_K8S_INCLUDE_PODS"

--- a/deploy/configuration.yaml
+++ b/deploy/configuration.yaml
@@ -77,6 +77,8 @@
       kubernetes-enable-node-metrics: "true"
       ## enable kubelet cadvisor metrics
       kubernetes-enable-cadvisor-metrics: "false"
+      ## enable kube-dns metrics
+      kubernetes-enable-kube-dns-metrics: "false"
       ## include pod metrics, requires nodes to be enabled
       kubernetes-include-pod-metrics: "true"
       ## include only pods with this label key, blank = all pods
@@ -112,6 +114,7 @@
             ["allow","^capacity_.*$","node capacity"],
             ["allow","^kube_namespace_status_phase$","tags","and(or(phase:Active,phase:Terminating))","namespaces"],
             ["allow","^collect_.*$","agent collection stats"],
+            ["allow","^coredns_.*$","kube-dns"],
             ["allow","^events$","events"],
             ["deny","^.+$","all other metrics"]
           ]

--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -5,28 +5,28 @@
     name: circonus-kubernetes-agent
     labels:
       app.kubernetes.io/name: circonus-kubernetes-agent
-      app.kubernetes.io/version: v0.6.1
+      app.kubernetes.io/version: v0.6.2
   spec:
     selector:
       matchLabels:
         app.kubernetes.io/name: circonus-kubernetes-agent
-        app.kubernetes.io/version: v0.6.1
+        app.kubernetes.io/version: v0.6.2
     replicas: 1
     template:
       metadata:
         name: circonus-kubernetes-agent
         labels:
           app.kubernetes.io/name: circonus-kubernetes-agent
-          app.kubernetes.io/version: v0.6.1
+          app.kubernetes.io/version: v0.6.2
       spec:
         nodeSelector:
           kubernetes.io/os: linux
         serviceAccountName: circonus-kubernetes-agent
         containers:
           - name: circonus-kubernetes-agent
-            image: circonuslabs/circonus-kubernetes-agent:v0.6.1
+            image: circonuslabs/circonus-kubernetes-agent:v0.6.2
             ## for ARM64, remove line above and uncomment line below
-            #image: circonuslabs/circonus-kubernetes-agent-arm64:v0.6.1
+            #image: circonuslabs/circonus-kubernetes-agent-arm64:v0.6.2
             command: ["/circonus-kubernetes-agentd"]
             args: 
               #- --debug

--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -176,6 +176,11 @@
                   configMapKeyRef:
                     name: cka-config-v1
                     key: kubernetes-enable-cadvisor-metrics
+              - name: CKA_K8S_ENABLE_KUBE_DNS_METRICS
+                valueFrom:
+                  configMapKeyRef:
+                    name: cka-config-v1
+                    key: kubernetes-enable-kube-dns-metrics
               - name: CKA_K8S_INCLUDE_CONTAINER_METRICS
                 valueFrom:
                   configMapKeyRef:

--- a/internal/circonus/check.go
+++ b/internal/circonus/check.go
@@ -355,6 +355,7 @@ func (c *Check) loadMetricFilters() [][]string {
 		{"allow", "^kube_namespace_status_phase$", "tags", "and(or(phase:Active,phase:Terminating))", "namespaces"},
 		{"allow", "^collect_.*$", "agent collection stats"},
 		{"allow", "^events$", "events"},
+		{"allow", "^coredns_.*$", "kube-dns"},
 		{"deny", "^.+$", "all other metrics}"},
 	}
 

--- a/internal/circonus/submit.go
+++ b/internal/circonus/submit.go
@@ -15,7 +15,6 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
-	"net/http/httputil"
 	"os"
 	"path"
 	"strconv"
@@ -246,15 +245,16 @@ func (c *Check) Submit(ctx context.Context, metrics io.Reader, resultLogger zero
 		req.Header.Set("Content-Encoding", "gzip")
 	}
 
-	if c.DebugSubmissions() {
-		dump, e := httputil.DumpRequestOut(req.Request, !payloadIsCompressed)
-		if e != nil {
-			resultLogger.Error().Err(e).Msg("dumping request")
-			return e
-		}
+	// doesn't work with retryablehttp
+	// if c.DebugSubmissions() {
+	// 	dump, e := httputil.DumpRequestOut(req.Request, !payloadIsCompressed)
+	// 	if e != nil {
+	// 		resultLogger.Error().Err(e).Msg("dumping request")
+	// 		return e
+	// 	}
 
-		fmt.Println(string(dump))
-	}
+	// 	fmt.Println(string(dump))
+	// }
 
 	retryClient := retryablehttp.NewClient()
 	retryClient.HTTPClient = client

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -40,6 +40,7 @@ type Cluster struct {
 	EnableNodeStats        bool   `mapstructure:"enable_node_stats" json:"enable_node_stats" toml:"enable_node_stats" yaml:"enable_node_stats"`
 	EnableNodeMetrics      bool   `mapstructure:"enable_node_metrics" json:"enable_node_metrics" toml:"enable_node_metrics" yaml:"enable_node_metrics"`
 	EnableCadvisorMetrics  bool   `mapstructure:"enable_cadvisor_metrics" json:"enable_cadvisor_metrics" toml:"enable_cadvisor_metrics" yaml:"enable_cadvisor_metrics"`
+	EnableKubeDNSMetrics   bool   `mapstructure:"enable_kube_dns_metrics" json:"enable_kube_dns_metrics" toml:"enable_kube_dns_metrics" yaml:"enable_kube_dns_metrics"`
 	IncludeContainers      bool   `mapstructure:"include_container_metrics" json:"include_container_metrics" toml:"include_container_metrics" yaml:"include_container_metrics"`
 	IncludePods            bool   `mapstructure:"include_pod_metrics" json:"include_pod_metrics" toml:"include_pod_metrics" yaml:"include_pod_metrics"`
 	PodLabelKey            string `mapstructure:"pod_label_key" json:"pod_label_key" toml:"pod_label" yaml:"pod_label_key"`

--- a/internal/config/defaults/defaults.go
+++ b/internal/config/defaults/defaults.go
@@ -30,6 +30,7 @@ const (
 	CheckBrokerCAFile  = ""
 	CheckMetricFilters = ""
 	CheckTags          = ""
+	CheckTarget        = "" // defaults to cluster name
 	DefaultStreamtags  = ""
 	CheckTitle         = ""
 	TraceSubmits       = ""
@@ -77,6 +78,7 @@ const (
 	K8SEnableNodeStats        = true
 	K8SEnableNodeMetrics      = true
 	K8SEnableCadvisorMetrics  = false
+	K8SEnableKubeDNSMetrics   = false
 	K8SNodeSelector           = "" // blank=all
 	K8SIncludePods            = true
 	K8SPodLabelKey            = "" // blank=all
@@ -99,9 +101,6 @@ var (
 
 	// ConfigFile defines the default configuration file name
 	ConfigFile = ""
-
-	// CheckTarget defaults to return from os.Hostname()
-	CheckTarget = ""
 
 	// K8SNodePoolSize defaults to number of available cpus for concurrent collection of metrics
 	K8SNodePoolSize = runtime.NumCPU()
@@ -127,10 +126,4 @@ func init() {
 
 	EtcPath = filepath.Join(BasePath, "etc")
 	ConfigFile = filepath.Join(EtcPath, release.NAME+".yaml")
-
-	CheckTarget, err = os.Hostname()
-	if err != nil {
-		fmt.Printf("Unable to determine hostname for target %v\n", err)
-		os.Exit(1)
-	}
 }

--- a/internal/config/keys/keys.go
+++ b/internal/config/keys/keys.go
@@ -148,6 +148,9 @@ const (
 	// K8SEnableCadvisorMetrics - kublet /metrics/cadvisor metrics
 	K8SEnableCadvisorMetrics = "kubernetes.enable_cadvisor_metrics"
 
+	// K8SEnableKubeDNSMetrics - collect kube-dns metrics
+	K8SEnableKubeDNSMetrics = "kubernetes.enable_kube_dns"
+
 	// K8SEnableEvents enable events
 	K8SEnableEvents = "kubernetes.enable_events"
 

--- a/internal/dns/dns.go
+++ b/internal/dns/dns.go
@@ -1,0 +1,277 @@
+// Copyright © 2019 Circonus, Inc. <support@circonus.com>
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+
+// Package dns is the kube-dns collector
+package dns
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"sync"
+	"time"
+
+	cgm "github.com/circonus-labs/circonus-gometrics/v3"
+	"github.com/circonus-labs/circonus-kubernetes-agent/internal/circonus"
+	"github.com/circonus-labs/circonus-kubernetes-agent/internal/config"
+	"github.com/circonus-labs/circonus-kubernetes-agent/internal/config/defaults"
+	"github.com/circonus-labs/circonus-kubernetes-agent/internal/k8s"
+	"github.com/circonus-labs/circonus-kubernetes-agent/internal/promtext"
+	"github.com/circonus-labs/circonus-kubernetes-agent/internal/release"
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog"
+)
+
+type DNS struct {
+	config       *config.Cluster
+	check        *circonus.Check
+	log          zerolog.Logger
+	running      bool
+	apiTimelimit time.Duration
+	sync.Mutex
+	ts *time.Time
+}
+
+func New(cfg *config.Cluster, parentLog zerolog.Logger, check *circonus.Check) (*DNS, error) {
+	if cfg == nil {
+		return nil, errors.New("invalid cluster config (nil)")
+	}
+	if check == nil {
+		return nil, errors.New("invalid check (nil)")
+	}
+
+	dns := &DNS{
+		config: cfg,
+		check:  check,
+		log:    parentLog.With().Str("collector", "kube-dns").Logger(),
+	}
+
+	if cfg.APITimelimit != "" {
+		v, err := time.ParseDuration(cfg.APITimelimit)
+		if err != nil {
+			dns.log.Error().Err(err).Msg("parsing api timelimit, using default")
+		} else {
+			dns.apiTimelimit = v
+		}
+	}
+
+	if dns.apiTimelimit == time.Duration(0) {
+		v, err := time.ParseDuration(defaults.K8SAPITimelimit)
+		if err != nil {
+			dns.log.Fatal().Err(err).Msg("parsing DEFAULT api timelimit")
+		}
+		dns.apiTimelimit = v
+	}
+
+	return dns, nil
+}
+
+func (dns *DNS) ID() string {
+	return "kube-dns"
+}
+
+func (dns *DNS) Collect(ctx context.Context, tlsConfig *tls.Config, ts *time.Time) {
+	dns.Lock()
+	if dns.running {
+		dns.log.Warn().Msg("already running")
+		dns.Unlock()
+		return
+	}
+	dns.running = true
+	dns.ts = ts
+	dns.Unlock()
+
+	defer func() {
+		if r := recover(); r != nil {
+			dns.log.Error().Interface("panic", r).Msg("recover")
+			dns.Lock()
+			dns.running = false
+			dns.Unlock()
+		}
+	}()
+
+	collectStart := time.Now()
+	svc, err := dns.getServiceDefinition(tlsConfig)
+	if err != nil {
+		dns.log.Error().Err(err).Msg("service definition")
+		dns.Lock()
+		dns.running = false
+		dns.Unlock()
+		return
+	}
+	if svc == nil {
+		dns.log.Error().Msg("invalid service definition (nil)")
+		dns.Lock()
+		dns.running = false
+		dns.Unlock()
+		return
+	}
+
+	metricPath := "/proxy/metrics"
+	metricPortName := ""
+	for _, p := range svc.Spec.Ports {
+		if p.Name == "metrics" {
+			metricPortName = p.Name
+		}
+	}
+
+	if metricPortName == "" {
+		dns.log.Error().Msg("invalid service definition, port named 'metrics' not found")
+		dns.Lock()
+		dns.running = false
+		dns.Unlock()
+		return
+	}
+
+	metricURL := dns.config.URL + svc.Metadata.SelfLink + ":" + metricPortName + metricPath
+
+	if err := dns.metrics(ctx, tlsConfig, metricURL); err != nil {
+		dns.log.Error().Err(err).Str("url", metricURL).Msg("http-metrics")
+	}
+
+	dns.check.AddHistSample("collect_latency", cgm.Tags{
+		cgm.Tag{Category: "source", Value: release.NAME},
+		cgm.Tag{Category: "opt", Value: "collect_kube-dns"},
+		cgm.Tag{Category: "units", Value: "milliseconds"},
+	}, float64(time.Since(collectStart).Milliseconds()))
+	dns.log.Debug().Str("duration", time.Since(collectStart).String()).Msg("kube-dns collect end")
+	dns.Lock()
+	dns.running = false
+	dns.Unlock()
+}
+
+func (dns *DNS) getServiceDefinition(tlsConfig *tls.Config) (*k8s.Service, error) {
+	u, err := url.Parse(dns.config.URL + "/api/v1/services")
+	if err != nil {
+		return nil, err
+	}
+
+	q := u.Query()
+	q.Set("fieldSelector", "metadata.name=kube-dns")
+	u.RawQuery = q.Encode()
+
+	client, err := k8s.NewAPIClient(tlsConfig, dns.apiTimelimit)
+	if err != nil {
+		return nil, errors.Wrap(err, "service definition cli")
+	}
+	defer client.CloseIdleConnections()
+
+	reqURL := u.String()
+	dns.log.Debug().Str("url", reqURL).Msg("service")
+	req, err := k8s.NewAPIRequest(dns.config.BearerToken, reqURL)
+	if err != nil {
+		return nil, errors.Wrap(err, "service definition req")
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		dns.check.IncrementCounter("collect_api_errors", cgm.Tags{
+			cgm.Tag{Category: "source", Value: release.NAME},
+			cgm.Tag{Category: "request", Value: "kube-dns_service"},
+			cgm.Tag{Category: "target", Value: "api-server"},
+		})
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		dns.check.IncrementCounter("collect_api_errors", cgm.Tags{
+			cgm.Tag{Category: "source", Value: release.NAME},
+			cgm.Tag{Category: "request", Value: "kube-dns_service"},
+			cgm.Tag{Category: "target", Value: "api-server"},
+			cgm.Tag{Category: "code", Value: fmt.Sprintf("%d", resp.StatusCode)},
+		})
+		data, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			dns.log.Error().Err(err).Str("url", reqURL).Msg("reading response")
+			return nil, err
+		}
+		dns.log.Warn().Str("status", resp.Status).RawJSON("response", data).Msg("error from API server")
+		return nil, errors.New("error response from api server")
+	}
+
+	var s k8s.ServiceList
+	if err := json.NewDecoder(resp.Body).Decode(&s); err != nil {
+		return nil, err
+	}
+
+	if len(s.Items) == 0 {
+		return nil, errors.New("no 'kube-dns' service found")
+	}
+
+	if len(s.Items) > 1 {
+		return nil, fmt.Errorf("multiple (%d) 'kube-dns' services found", len(s.Items))
+	}
+
+	return s.Items[0], nil
+}
+
+func (dns *DNS) metrics(ctx context.Context, tlsConfig *tls.Config, metricURL string) error {
+	client, err := k8s.NewAPIClient(tlsConfig, dns.apiTimelimit)
+	if err != nil {
+		return errors.Wrap(err, "/metrics cli")
+	}
+	defer client.CloseIdleConnections()
+
+	dns.log.Debug().Str("url", metricURL).Msg("metrics")
+	req, err := k8s.NewAPIRequest(dns.config.BearerToken, metricURL)
+	if err != nil {
+		return errors.Wrap(err, "/metrics req")
+	}
+
+	start := time.Now()
+	resp, err := client.Do(req)
+	if err != nil {
+		dns.check.IncrementCounter("collect_api_errors", cgm.Tags{
+			cgm.Tag{Category: "source", Value: release.NAME},
+			cgm.Tag{Category: "request", Value: "metrics"},
+			cgm.Tag{Category: "proxy", Value: "api-server"},
+			cgm.Tag{Category: "target", Value: "kube-dns"},
+		})
+		return err
+	}
+	defer resp.Body.Close()
+	dns.check.AddHistSample("collect_latency", cgm.Tags{
+		cgm.Tag{Category: "source", Value: release.NAME},
+		cgm.Tag{Category: "request", Value: "metrics"},
+		cgm.Tag{Category: "proxy", Value: "api-server"},
+		cgm.Tag{Category: "target", Value: "kube-dns"},
+		cgm.Tag{Category: "units", Value: "milliseconds"},
+	}, float64(time.Since(start).Milliseconds()))
+
+	if resp.StatusCode != http.StatusOK {
+		dns.check.IncrementCounter("collect_api_errors", cgm.Tags{
+			cgm.Tag{Category: "source", Value: release.NAME},
+			cgm.Tag{Category: "request", Value: "metrics"},
+			cgm.Tag{Category: "proxy", Value: "api-server"},
+			cgm.Tag{Category: "target", Value: "kube-dns"},
+			cgm.Tag{Category: "code", Value: fmt.Sprintf("%d", resp.StatusCode)},
+		})
+		data, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			dns.log.Error().Err(err).Str("url", metricURL).Msg("reading response")
+			return err
+		}
+		dns.log.Warn().Str("status", resp.Status).RawJSON("response", data).Msg("error from API server")
+		return errors.New("error response from api server")
+	}
+
+	streamTags := []string{
+		"source:kube-dns",
+		"source_type:metrics",
+		"__rollup:false", // prevent high cardinality metrics from rolling up
+	}
+	measurementTags := []string{}
+
+	if err := promtext.QueueMetrics(ctx, dns.check, dns.log, resp.Body, streamTags, measurementTags, dns.ts); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/dns/dns_test.go
+++ b/internal/dns/dns_test.go
@@ -1,0 +1,12 @@
+// Copyright © 2019 Circonus, Inc. <support@circonus.com>
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+
+package dns
+
+import "testing"
+
+func Test(t *testing.T) {
+	t.Log("Placeholder...nothing to test currently")
+}

--- a/internal/k8s/service.go
+++ b/internal/k8s/service.go
@@ -21,8 +21,8 @@ type ServiceSpec struct {
 	Ports []ServicePort `json:"ports"`
 }
 type ServicePort struct {
-	Name       string `json:"name"`
-	Protocol   string `json:"protocol"`
-	Port       uint   `json:"port"`
-	TargetPort string `json:"targetPort"`
+	Name       string      `json:"name"`
+	Protocol   string      `json:"protocol"`
+	Port       uint        `json:"port"`
+	TargetPort interface{} `json:"targetPort"`
 }

--- a/internal/ksm/ksm.go
+++ b/internal/ksm/ksm.go
@@ -132,6 +132,21 @@ func (ksm *KSM) Collect(ctx context.Context, tlsConfig *tls.Config, ts *time.Tim
 		}
 	}
 
+	if metricPortName == "" && telemetryPortName == "" {
+		ksm.log.Error().Msg("invalid service definition, ports named 'http-metrics' and 'telemetry' not found")
+		ksm.Lock()
+		ksm.running = false
+		ksm.Unlock()
+		return
+	}
+
+	if metricPortName == "" {
+		ksm.log.Warn().Str("port", "http-metrics").Msg("metrics port not found in service definition")
+	}
+	if telemetryPortName == "" {
+		ksm.log.Warn().Str("port", "telemetry").Msg("telemetry port not found in service definition")
+	}
+
 	var wg sync.WaitGroup
 
 	if metricPortName != "" {

--- a/internal/ksm/ksm.go
+++ b/internal/ksm/ksm.go
@@ -186,6 +186,7 @@ func (ksm *KSM) getServiceDefinition(tlsConfig *tls.Config) (*k8s.Service, error
 	defer client.CloseIdleConnections()
 
 	reqURL := u.String()
+	ksm.log.Debug().Str("url", reqURL).Msg("service")
 	req, err := k8s.NewAPIRequest(ksm.config.BearerToken, reqURL)
 	if err != nil {
 		return nil, errors.Wrap(err, "service definition req")
@@ -241,6 +242,7 @@ func (ksm *KSM) metrics(ctx context.Context, tlsConfig *tls.Config, metricURL st
 	}
 	defer client.CloseIdleConnections()
 
+	ksm.log.Debug().Str("url", metricURL).Msg("metrics")
 	req, err := k8s.NewAPIRequest(ksm.config.BearerToken, metricURL)
 	if err != nil {
 		return errors.Wrap(err, "/metrics req")
@@ -290,15 +292,9 @@ func (ksm *KSM) metrics(ctx context.Context, tlsConfig *tls.Config, metricURL st
 	}
 	measurementTags := []string{}
 
-	// if ksm.check.StreamMetrics() {
-	// 	if err := promtext.StreamMetrics(ctx, ksm.check, ksm.log, resp.Body, streamTags, measurementTags, ksm.ts); err != nil {
-	// 		return err
-	// 	}
-	// } else {
 	if err := promtext.QueueMetrics(ctx, ksm.check, ksm.log, resp.Body, streamTags, measurementTags, ksm.ts); err != nil {
 		return err
 	}
-	// }
 
 	return nil
 }
@@ -310,6 +306,7 @@ func (ksm *KSM) telemetry(ctx context.Context, tlsConfig *tls.Config, telemetryU
 	}
 	defer client.CloseIdleConnections()
 
+	ksm.log.Debug().Str("url", telemetryURL).Msg("telemetry")
 	req, err := k8s.NewAPIRequest(ksm.config.BearerToken, telemetryURL)
 	if err != nil {
 		return errors.Wrap(err, "/telemetry req")
@@ -359,15 +356,9 @@ func (ksm *KSM) telemetry(ctx context.Context, tlsConfig *tls.Config, telemetryU
 	}
 	measurementTags := []string{}
 
-	// if ksm.check.StreamMetrics() {
-	// 	if err := promtext.StreamMetrics(ctx, ksm.check, ksm.log, resp.Body, streamTags, measurementTags, ksm.ts); err != nil {
-	// 		return err
-	// 	}
-	// } else {
 	if err := promtext.QueueMetrics(ctx, ksm.check, ksm.log, resp.Body, streamTags, measurementTags, ksm.ts); err != nil {
 		return err
 	}
-	// }
 
 	return nil
 }


### PR DESCRIPTION
* add: optional, metric collection for kube-dns
* upd: default check.target to cluster.name if target is unset
* add: error if neither metric or telemetry ports found in ksm service definition
* add: warn if metric port not found in ksm service definition
* add: warn if telemetry port not found in ksm service definition
* add: debug message for ksm urls being used
