### PR TITLE
v0.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.6.3
+
+* add: make kube-state-metrics port names for metrics and telemetry configurable. Default from ['standard' service deployment](https://github.com/kubernetes/kube-state-metrics/blob/master/examples/standard/service.yaml). metrics=`http-metrics` and telemetry=`telemetry`.
+
 # v0.6.2
 
 * add: optional, metric collection for kube-dns

--- a/cmd/args_kubernetes.go
+++ b/cmd/args_kubernetes.go
@@ -171,6 +171,44 @@ func init() {
 
 	{
 		const (
+			key          = keys.K8SKSMMetricsPortName
+			longOpt      = "k8s-ksm-metrics-port-name"
+			envVar       = release.ENVPREFIX + "_K8S_KSM_METRICS_PORT_NAME"
+			description  = "Kube-state-metrics metrics port name"
+			defaultValue = defaults.K8SKSMMetricsPortName
+		)
+
+		rootCmd.PersistentFlags().String(longOpt, defaultValue, envDescription(description, envVar))
+		if err := viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)); err != nil {
+			bindFlagError(longOpt, err)
+		}
+		if err := viper.BindEnv(key, envVar); err != nil {
+			bindEnvError(envVar, err)
+		}
+		viper.SetDefault(key, defaultValue)
+	}
+
+	{
+		const (
+			key          = keys.K8SKSMTelemetryPortName
+			longOpt      = "k8s-ksm-telemetry-port-name"
+			envVar       = release.ENVPREFIX + "_K8S_KSM_TELEMETRY_PORT_NAME"
+			description  = "Kube-state-metrics telemetry port name"
+			defaultValue = defaults.K8SKSMTelemetryPortName
+		)
+
+		rootCmd.PersistentFlags().String(longOpt, defaultValue, envDescription(description, envVar))
+		if err := viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)); err != nil {
+			bindFlagError(longOpt, err)
+		}
+		if err := viper.BindEnv(key, envVar); err != nil {
+			bindEnvError(envVar, err)
+		}
+		viper.SetDefault(key, defaultValue)
+	}
+
+	{
+		const (
 			key          = keys.K8SEnableMetricsServer
 			longOpt      = "k8s-enable-metrics-server"
 			envVar       = release.ENVPREFIX + "_K8S_ENABLE_METRICS_SERVER"

--- a/deploy/configuration.yaml
+++ b/deploy/configuration.yaml
@@ -65,6 +65,10 @@
       kubernetes-enable-events: "false"
       ## collect metrics from kube-state-metrics if running
       kubernetes-enable-kube-state-metrics: "false"
+      ## kube-state-metrics metrics port name, default from https://github.com/kubernetes/kube-state-metrics/blob/master/examples/standard/service.yaml
+      kubernetes-ksm-metrics-port-name: "http-metrics"
+      ## kube-state-metrics telemetry port name, default from https://github.com/kubernetes/kube-state-metrics/blob/master/examples/standard/service.yaml
+      kubernetes-ksm-telemetry-port-name: "telemetry"
       ## collect metrics from metrics-server if running
       kubernetes-enable-metrics-server: "false"
       ## collect node metrics

--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -146,6 +146,16 @@
                   configMapKeyRef:
                     name: cka-config-v1
                     key: kubernetes-enable-kube-state-metrics
+              - name: CKA_K8S_KSM_METRICS_PORT_NAME
+                valueFrom:
+                  configMapKeyRef:
+                    name: cka-config-v1
+                    key: kubernetes-ksm-metrics-port-name
+              - name: CKA_K8S_KSM_TELEMETRY_PORT_NAME
+                valueFrom:
+                  configMapKeyRef:
+                    name: cka-config-v1
+                    key: kubernetes-ksm-telemetry-port-name
               - name: CKA_K8S_ENABLE_METRICS_SERVER
                 valueFrom:
                   configMapKeyRef:

--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -5,28 +5,28 @@
     name: circonus-kubernetes-agent
     labels:
       app.kubernetes.io/name: circonus-kubernetes-agent
-      app.kubernetes.io/version: v0.6.2
+      app.kubernetes.io/version: v0.6.3
   spec:
     selector:
       matchLabels:
         app.kubernetes.io/name: circonus-kubernetes-agent
-        app.kubernetes.io/version: v0.6.2
+        app.kubernetes.io/version: v0.6.3
     replicas: 1
     template:
       metadata:
         name: circonus-kubernetes-agent
         labels:
           app.kubernetes.io/name: circonus-kubernetes-agent
-          app.kubernetes.io/version: v0.6.2
+          app.kubernetes.io/version: v0.6.3
       spec:
         nodeSelector:
           kubernetes.io/os: linux
         serviceAccountName: circonus-kubernetes-agent
         containers:
           - name: circonus-kubernetes-agent
-            image: circonuslabs/circonus-kubernetes-agent:v0.6.2
+            image: circonuslabs/circonus-kubernetes-agent:v0.6.3
             ## for ARM64, remove line above and uncomment line below
-            #image: circonuslabs/circonus-kubernetes-agent-arm64:v0.6.2
+            #image: circonuslabs/circonus-kubernetes-agent-arm64:v0.6.3
             command: ["/circonus-kubernetes-agentd"]
             args: 
               #- --debug

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -34,6 +34,8 @@ type Cluster struct {
 	BearerTokenFile        string `mapstructure:"bearer_token_file" json:"bearer_token_file" toml:"bearer_token_file" yaml:"bearer_token_file"`
 	EnableEvents           bool   `mapstructure:"enable_events" json:"enable_events" toml:"enable_events" yaml:"enable_events"`
 	EnableKubeStateMetrics bool   `mapstructure:"enable_kube_state_metrics" json:"enable_kube_state_metrics" toml:"enable_kube_state_metrics" yaml:"enable_kube_state_metrics"`
+	KSMMetricsPortName     string `mapstructure:"ksm_metrics_port_name" json:"ksm_metrics_port_name" toml:"ksm_metrics_port_name" yaml:"ksm_metrics_port_name"`
+	KSMTelemetryPortName   string `mapstructure:"ksm_telemetry_port_name" json:"ksm_telemetry_port_name" toml:"ksm_telemetry_port_name" yaml:"ksm_telemetry_port_name"`
 	EnableMetricServer     bool   `mapstructure:"enable_metrics_server" json:"enable_metrics_server" toml:"enable_metrics_server" yaml:"enable_metrics_server"`
 	EnableNodes            bool   `mapstructure:"enable_nodes" json:"enable_nodes" toml:"enable_nodes" yaml:"enable_nodes"`
 	NodeSelector           string `mapstructure:"node_selector" json:"node_selector" toml:"node_selector" yaml:"node_selector"`

--- a/internal/config/defaults/defaults.go
+++ b/internal/config/defaults/defaults.go
@@ -73,6 +73,8 @@ const (
 	K8SBearerTokenFile        = "/var/run/secrets/kubernetes.io/serviceaccount/token" //nolint:gosec
 	K8SEnableEvents           = false
 	K8SEnableKubeStateMetrics = false
+	K8SKSMMetricsPortName     = "http-metrics" // default from 'standard' service deployment, https://github.com/kubernetes/kube-state-metrics/blob/master/examples/standard/service.yaml#L11
+	K8SKSMTelemetryPortName   = "telemetry"    // default from 'standard' service deployment, https://github.com/kubernetes/kube-state-metrics/blob/master/examples/standard/service.yaml#L11
 	K8SEnableMetricsServer    = false
 	K8SEnableNodes            = true
 	K8SEnableNodeStats        = true

--- a/internal/config/keys/keys.go
+++ b/internal/config/keys/keys.go
@@ -156,6 +156,8 @@ const (
 
 	// K8SEnableKubeStateMetrics enable kube-state-metrics
 	K8SEnableKubeStateMetrics = "kubernetes.enable_kube_state_metrics"
+	K8SKSMMetricsPortName     = "kubernetes.ksm_metrics_port_name"
+	K8SKSMTelemetryPortName   = "kubernetes.ksm_telemetry_port_name"
 
 	// K8SEnableMetricsServer enable metrics-server
 	K8SEnableMetricsServer = "kubernetes.enable_metrics_server"


### PR DESCRIPTION
* add: make kube-state-metrics port names for metrics and telemetry configurable. Default from ['standard' service deployment](https://github.com/kubernetes/kube-state-metrics/blob/master/examples/standard/service.yaml). metrics=`http-metrics` and telemetry=`telemetry`.
