### PR TITLE
add a KSMFieldSelectorQuery option for working with non-standard KSM installs

### DIFF
--- a/cmd/args_kubernetes.go
+++ b/cmd/args_kubernetes.go
@@ -209,6 +209,25 @@ func init() {
 
 	{
 		const (
+			key          = keys.K8SKSMFieldSelectorQuery
+			longOpt      = "k8s-ksm-field-selector-query"
+			envVar       = release.ENVPREFIX + "_K8S_KSM_FIELD_SELECTOR_QUERY"
+			description  = "Kube-state-metrics fieldSelector query for finding the correct KSM installation"
+			defaultValue = defaults.K8SKSMFieldSelectorQuery
+		)
+
+		rootCmd.PersistentFlags().String(longOpt, defaultValue, envDescription(description, envVar))
+		if err := viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)); err != nil {
+			bindFlagError(longOpt, err)
+		}
+		if err := viper.BindEnv(key, envVar); err != nil {
+			bindEnvError(envVar, err)
+		}
+		viper.SetDefault(key, defaultValue)
+	}
+
+	{
+		const (
 			key          = keys.K8SEnableAPIServer
 			longOpt      = "k8s-enable-api-server"
 			envVar       = release.ENVPREFIX + "_K8S_ENABLE_API_SERVER"

--- a/deploy/configuration.yaml
+++ b/deploy/configuration.yaml
@@ -69,6 +69,8 @@
       kubernetes-ksm-metrics-port-name: "http-metrics"
       ## kube-state-metrics telemetry port name, default from https://github.com/kubernetes/kube-state-metrics/blob/master/examples/standard/service.yaml
       kubernetes-ksm-telemetry-port-name: "telemetry"
+      ## kube-state-metrics fieldSelector query, default from https://github.com/kubernetes/kube-state-metrics/blob/master/examples/standard/service.yaml
+      kubernetes-ksm-field-selector-query: "metadata.name=kube-state-metrics"
       ## collect metrics from api-server
       kubernetes-enable-api-server: "true"
       ## collect node metrics

--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -158,6 +158,11 @@
                   configMapKeyRef:
                     name: cka-config-v1
                     key: kubernetes-ksm-telemetry-port-name
+              - name: CKA_K8S_KSM_FIELD_SELECTOR_QUERY
+                valueFrom:
+                  configMapKeyRef:
+                    name: cka-config-v1
+                    key: kubernetes-ksm-field-selector-query
               - name: CKA_K8S_ENABLE_API_SERVER
                 valueFrom:
                   configMapKeyRef:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -36,6 +36,7 @@ type Cluster struct {
 	EnableKubeStateMetrics bool   `mapstructure:"enable_kube_state_metrics" json:"enable_kube_state_metrics" toml:"enable_kube_state_metrics" yaml:"enable_kube_state_metrics"`
 	KSMMetricsPortName     string `mapstructure:"ksm_metrics_port_name" json:"ksm_metrics_port_name" toml:"ksm_metrics_port_name" yaml:"ksm_metrics_port_name"`
 	KSMTelemetryPortName   string `mapstructure:"ksm_telemetry_port_name" json:"ksm_telemetry_port_name" toml:"ksm_telemetry_port_name" yaml:"ksm_telemetry_port_name"`
+	KSMFieldSelectorQuery  string `mapstructure:"ksm_field_selector_query" json:"ksm_field_selector_query" toml:"ksm_field_selector_query" yaml:"ksm_field_selector_query"`
 	EnableAPIServer        bool   `mapstructure:"enable_api_server" json:"enable_api_server" toml:"enable_api_server" yaml:"enable_metrics_server"`
 	EnableNodes            bool   `mapstructure:"enable_nodes" json:"enable_nodes" toml:"enable_nodes" yaml:"enable_nodes"`
 	NodeSelector           string `mapstructure:"node_selector" json:"node_selector" toml:"node_selector" yaml:"node_selector"`

--- a/internal/config/defaults/defaults.go
+++ b/internal/config/defaults/defaults.go
@@ -71,8 +71,9 @@ const (
 	K8SBearerTokenFile        = "/var/run/secrets/kubernetes.io/serviceaccount/token" //nolint:gosec
 	K8SEnableEvents           = false
 	K8SEnableKubeStateMetrics = false
-	K8SKSMMetricsPortName     = "http-metrics" // default from 'standard' service deployment, https://github.com/kubernetes/kube-state-metrics/blob/master/examples/standard/service.yaml#L11
-	K8SKSMTelemetryPortName   = "telemetry"    // default from 'standard' service deployment, https://github.com/kubernetes/kube-state-metrics/blob/master/examples/standard/service.yaml#L11
+	K8SKSMMetricsPortName     = "http-metrics"                     // default from 'standard' service deployment, https://github.com/kubernetes/kube-state-metrics/blob/master/examples/standard/service.yaml#L11
+	K8SKSMTelemetryPortName   = "telemetry"                        // default from 'standard' service deployment, https://github.com/kubernetes/kube-state-metrics/blob/master/examples/standard/service.yaml#L11
+	K8SKSMFieldSelectorQuery  = "metadata.name=kube-state-metrics" // default from 'standard' service deployment, https://github.com/kubernetes/kube-state-metrics/blob/master/examples/standard/service.yaml#L19
 	K8SEnableAPIServer        = false
 	K8SEnableMetricsServer    = false
 	K8SEnableNodes            = true

--- a/internal/config/keys/keys.go
+++ b/internal/config/keys/keys.go
@@ -151,6 +151,7 @@ const (
 	K8SEnableKubeStateMetrics = "kubernetes.enable_kube_state_metrics"
 	K8SKSMMetricsPortName     = "kubernetes.ksm_metrics_port_name"
 	K8SKSMTelemetryPortName   = "kubernetes.ksm_telemetry_port_name"
+	K8SKSMFieldSelectorQuery  = "kubernetes.ksm_field_selector_query"
 
 	// K8SEnableAPIServer enable api-server
 	K8SEnableAPIServer = "kubernetes.enable_api_server"

--- a/internal/ksm/ksm.go
+++ b/internal/ksm/ksm.go
@@ -209,8 +209,15 @@ func (ksm *KSM) getServiceDefinition(tlsConfig *tls.Config) (*k8s.Service, error
 		return nil, err
 	}
 
+	if ksm.config.KSMFieldSelectorQuery == "" {
+		ksm.log.Error().
+			Str("field_selector_query", ksm.config.KSMFieldSelectorQuery).
+			Msg("invalid service definition, KSM field selectory query not found")
+		return nil, errors.New("invalid service definition, missing KSM field selector query")
+	}
+
 	q := u.Query()
-	q.Set("fieldSelector", "metadata.name=kube-state-metrics")
+	q.Set("fieldSelector", ksm.config.KSMFieldSelectorQuery)
 	u.RawQuery = q.Encode()
 
 	client, err := k8s.NewAPIClient(tlsConfig, ksm.apiTimelimit)


### PR DESCRIPTION
Google Anthos (on-prem GKE) installs it's own copy of KSM at version 1.14. On top of this they only expose a single port through the KSM service, and it’s backed by an rbac proxy.

To work around this, we want to install another KSM in our own namespace so we need to control which KSM is chosen by CKA.
