### PR TITLE
v0.9.3

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,5 +16,4 @@ jobs:
         uses: golangci/golangci-lint-action@v1
         with:
           version: v1.28
-          # Optional: golangci-lint command line arguments.
-          # args: --issues-exit-code=0
+          args: --timeout=5m

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# v0.9.3
+
+* fix: broker cn check both ip and external_host
+* upd: add debug line when using custom api ca  cert
+* upd: use `latest` for default (simple) deployment
+* upd: remove path validation from api url
+* upd: add `/v2` path to default api url
+
 # v0.9.2
 
 * upd: explicit cases for prometheus metric types

--- a/deploy/custom/configuration.yaml
+++ b/deploy/custom/configuration.yaml
@@ -34,7 +34,7 @@
   data:
       #circonus-api-key-file: ""
       #circonus-api-app: "circonus-kubernetes-agent"
-      #circonus-api-url: "https://api.circonus.com"
+      #circonus-api-url: "https://api.circonus.com/v2"
       #circonus-api-ca-file: ""
       #circonus-api-debug: "false"
       ## broker to use when creating a new httptrap check

--- a/deploy/default/deployment.yaml
+++ b/deploy/default/deployment.yaml
@@ -5,26 +5,26 @@
     name: circonus-kubernetes-agent
     labels:
       app.kubernetes.io/name: circonus-kubernetes-agent
-      app.kubernetes.io/version: v0.9.2
+      app.kubernetes.io/version: latest
   spec:
     selector:
       matchLabels:
         app.kubernetes.io/name: circonus-kubernetes-agent
-        app.kubernetes.io/version: v0.9.2
+        app.kubernetes.io/version: latest
     replicas: 1
     template:
       metadata:
         name: circonus-kubernetes-agent
         labels:
           app.kubernetes.io/name: circonus-kubernetes-agent
-          app.kubernetes.io/version: v0.9.2
+          app.kubernetes.io/version: latest
       spec:
         serviceAccountName: circonus-kubernetes-agent
         containers:
           - name: circonus-kubernetes-agent
-            image: circonuslabs/circonus-kubernetes-agent:v0.9.2
+            image: circonuslabs/circonus-kubernetes-agent:latest
             ## for ARM64, remove line above and uncomment line below
-            #image: circonuslabs/circonus-kubernetes-agent-arm64:v0.9.2
+            #image: circonuslabs/circonus-kubernetes-agent-arm64:latest
             command: ["/circonus-kubernetes-agentd"]
             env:
               - name: CKA_CIRCONUS_API_KEY

--- a/internal/circonus/broker.go
+++ b/internal/circonus/broker.go
@@ -108,7 +108,11 @@ func brokerCN(broker *apiclient.Broker, submissionURL string) (string, error) {
 	cn := ""
 
 	for _, detail := range broker.Details {
-		if *detail.IP == host {
+		if detail.IP != nil && *detail.IP == host {
+			cn = detail.CN
+			break
+		}
+		if detail.ExternalHost != nil && *detail.ExternalHost == host {
 			cn = detail.CN
 			break
 		}

--- a/internal/circonus/check.go
+++ b/internal/circonus/check.go
@@ -159,6 +159,7 @@ func (c *Check) createAPIClient() (*apiclient.API, error) {
 		Log:      apiLogshim{logh: c.log.With().Str("pkg", "apicli").Logger()},
 	}
 	if c.config.API.CAFile != "" {
+		c.log.Debug().Str("file", c.config.API.CAFile).Msg("adding CA cert to api client")
 		cert, err := ioutil.ReadFile(c.config.API.CAFile)
 		if err != nil {
 			return nil, errors.Wrap(err, "configuring API client")

--- a/internal/config/api.go
+++ b/internal/config/api.go
@@ -48,7 +48,7 @@ func validateAPIOptions(apiKey, apiKeyFile, apiApp, apiURL, apiCAFile string) er
 		if err != nil {
 			return errors.Wrap(err, "invalid API URL")
 		}
-		if parsedURL.Scheme == "" || parsedURL.Host == "" || parsedURL.Path == "" {
+		if parsedURL.Scheme == "" || parsedURL.Host == "" {
 			return errors.Errorf("invalid API URL (%s)", apiURL)
 		}
 	}


### PR DESCRIPTION
* fix: broker cn check both ip and external_host
* upd: add debug line when using custom api ca  cert
* upd: use `latest` for default (simple) deployment
* upd: remove path validation from api url
* upd: add `/v2` path to default api url