### PR TITLE
v0.9.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.9.4
+
+* add: kube-dns-metrics-port - used when scrape/port annotations are NOT defined on the kube-dns service (e.g. GKE)
+
 # v0.9.3
 
 * fix: broker cn check both ip and external_host

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ spec:
     targetPort: 9153
 ```
 
+> NOTE: if the annotations are _not_ defined on the service, and the service cannot be modfied for any reason. If the pods backing the kube-dns service _do_ expose metrics use `kube-dns-metrics-port` to define the port from which to request `/metrics`.
+
 ## Installation
 
 ### `kubectl`

--- a/cmd/args_kubernetes.go
+++ b/cmd/args_kubernetes.go
@@ -397,6 +397,24 @@ func init() {
 		}
 		viper.SetDefault(key, defaultValue)
 	}
+	{
+		const (
+			key          = keys.K8SKubeDNSMetricsPort
+			longOpt      = "k8s-kube-dns-metrics-port"
+			envVar       = release.ENVPREFIX + "_K8S_KUBE_DNS_METRICS_PORT"
+			description  = "Kube dns metrics port if annotations not on service definition"
+			defaultValue = defaults.K8SKubeDNSMetricsPort
+		)
+
+		rootCmd.PersistentFlags().String(longOpt, defaultValue, envDescription(description, envVar))
+		if err := viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)); err != nil {
+			bindFlagError(longOpt, err)
+		}
+		if err := viper.BindEnv(key, envVar); err != nil {
+			bindEnvError(envVar, err)
+		}
+		viper.SetDefault(key, defaultValue)
+	}
 
 	{
 		const (

--- a/deploy/custom/configuration.yaml
+++ b/deploy/custom/configuration.yaml
@@ -88,6 +88,8 @@
       kubernetes-enable-cadvisor-metrics: "false"
       ## enable kube-dns metrics - default is enabled for dashboard
       kubernetes-enable-kube-dns-metrics: "true"
+      ## port to request `/metrics` from if scrape/port annotations not defined on kube-dns service (e.g. GKE)
+      kubernetes-kube-dns-metrics-port: "10054"
       ## include pod metrics, requires nodes to be enabled - - default is enabled for dashboard
       kubernetes-include-pod-metrics: "true"
       ## include only pods with this label key, blank = all pods

--- a/deploy/custom/deployment.yaml
+++ b/deploy/custom/deployment.yaml
@@ -5,26 +5,26 @@
     name: circonus-kubernetes-agent
     labels:
       app.kubernetes.io/name: circonus-kubernetes-agent
-      app.kubernetes.io/version: v0.9.2
+      app.kubernetes.io/version: v0.9.4
   spec:
     selector:
       matchLabels:
         app.kubernetes.io/name: circonus-kubernetes-agent
-        app.kubernetes.io/version: v0.9.2
+        app.kubernetes.io/version: v0.9.4
     replicas: 1
     template:
       metadata:
         name: circonus-kubernetes-agent
         labels:
           app.kubernetes.io/name: circonus-kubernetes-agent
-          app.kubernetes.io/version: v0.9.2
+          app.kubernetes.io/version: v0.9.4
       spec:
         serviceAccountName: circonus-kubernetes-agent
         containers:
           - name: circonus-kubernetes-agent
-            image: circonuslabs/circonus-kubernetes-agent:v0.9.2
+            image: circonuslabs/circonus-kubernetes-agent:v0.9.4
             ## for ARM64, remove line above and uncomment line below
-            #image: circonuslabs/circonus-kubernetes-agent-arm64:v0.9.2
+            #image: circonuslabs/circonus-kubernetes-agent-arm64:v0.9.4
             command: ["/circonus-kubernetes-agentd"]
             args: 
               #- --debug
@@ -201,6 +201,11 @@
                   configMapKeyRef:
                     name: cka-config-v1
                     key: kubernetes-enable-kube-dns-metrics
+              - name: CKA_K8S_KUBE_DNS_METRICS_PORT
+                valueFrom:
+                  configMapKeyRef:
+                    name: cka-config-v1
+                    key: kubernetes-kube-dns-metrics-port
               - name: CKA_K8S_INCLUDE_CONTAINER_METRICS
                 valueFrom:
                   configMapKeyRef:

--- a/internal/config/defaults/defaults.go
+++ b/internal/config/defaults/defaults.go
@@ -85,6 +85,7 @@ const (
 	K8SEnableNodeMetrics      = true                                                  // dashboard
 	K8SEnableCadvisorMetrics  = false                                                 // not needed by dashboard and is deprecated by k8s
 	K8SEnableKubeDNSMetrics   = true                                                  // dashboard
+	K8SKubeDNSMetricsPort     = "10054"                                               // ONLY used if the kube-dns service does not have scrape and port annotations (e.g. GKE)
 	K8SNodeSelector           = ""                                                    // blank=all
 	K8SIncludePods            = true                                                  // dashboard
 	K8SPodLabelKey            = ""                                                    // blank=all

--- a/internal/config/keys/keys.go
+++ b/internal/config/keys/keys.go
@@ -152,6 +152,8 @@ const (
 
 	// K8SEnableKubeDNSMetrics - collect kube-dns metrics
 	K8SEnableKubeDNSMetrics = "kubernetes.enable_kube_dns_metrics"
+	// K8SKubeDNSMetricsPort - define when scrape/port annotations are not applied on the service
+	K8SKubeDNSMetricsPort = "kubernetes.kube_dns_metrics_port"
 
 	// K8SEnableEvents enable events
 	K8SEnableEvents = "kubernetes.enable_events"


### PR DESCRIPTION
* add: `kube-dns-metrics-port` - used when scrape/port annotations are NOT defined on the kube-dns service (e.g. GKE)