### PR TITLE
v0.11.0 CIRC-5871 CIRC-5875 CIRC-5890 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# v0.11.0
+
+* add: dynamic collectors - define objects (endpoints, nodes, pods, services) to collect metrics from in configuration CIRC-5871
+* upd: refactor ksm collection to be more intelligent w/re to port used (not all deployment methods name ports the same) CIRC-5890
+* add: static ksm port option to configuration CIRC-5890
+* upd: deprecate ksm mode and telemetry port options CIRC-5890
+* upd: `pod_pending`, `network_unavailable` and `cpu_utilization` rulesets with `windowing_min_duration` CIRC-5875
+* upd: return error when no metrics received from ksm so it can be expose in dashboard
+* upd: add check for NaN values (skip) in metric processing
+* upd: emit warning when no metrics to submit, with number processed (e.g. locally filtered)
+* upd: use epoch for log timestamps (performace)
+* upd: refactor cli arg handling
+
 # v0.10.4
 
 * add: additional logging for ksm collection/processing

--- a/cmd/args_circonus.go
+++ b/cmd/args_circonus.go
@@ -27,12 +27,8 @@ func init() {
 		)
 
 		rootCmd.PersistentFlags().String(longOpt, defaultValue, envDescription(description, envVar))
-		if err := viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)); err != nil {
-			bindFlagError(longOpt, err)
-		}
-		if err := viper.BindEnv(key, envVar); err != nil {
-			bindEnvError(envVar, err)
-		}
+		bindFlagError(longOpt, viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)))
+		bindEnvError(envVar, viper.BindEnv(key, envVar))
 		viper.SetDefault(key, defaultValue)
 	}
 
@@ -46,12 +42,8 @@ func init() {
 		)
 
 		rootCmd.PersistentFlags().String(longOpt, defaultValue, envDescription(description, envVar))
-		if err := viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)); err != nil {
-			bindFlagError(longOpt, err)
-		}
-		if err := viper.BindEnv(key, envVar); err != nil {
-			bindEnvError(envVar, err)
-		}
+		bindFlagError(longOpt, viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)))
+		bindEnvError(envVar, viper.BindEnv(key, envVar))
 		viper.SetDefault(key, defaultValue)
 	}
 
@@ -65,12 +57,8 @@ func init() {
 		)
 
 		rootCmd.PersistentFlags().String(longOpt, defaultValue, envDescription(description, envVar))
-		if err := viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)); err != nil {
-			bindFlagError(longOpt, err)
-		}
-		if err := viper.BindEnv(key, envVar); err != nil {
-			bindEnvError(envVar, err)
-		}
+		bindFlagError(longOpt, viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)))
+		bindEnvError(envVar, viper.BindEnv(key, envVar))
 		viper.SetDefault(key, defaultValue)
 	}
 
@@ -84,12 +72,8 @@ func init() {
 		)
 
 		rootCmd.PersistentFlags().String(longOpt, defaultValue, envDescription(description, envVar))
-		if err := viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)); err != nil {
-			bindFlagError(longOpt, err)
-		}
-		if err := viper.BindEnv(key, envVar); err != nil {
-			bindEnvError(envVar, err)
-		}
+		bindFlagError(longOpt, viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)))
+		bindEnvError(envVar, viper.BindEnv(key, envVar))
 		viper.SetDefault(key, defaultValue)
 	}
 
@@ -103,12 +87,8 @@ func init() {
 		)
 
 		rootCmd.PersistentFlags().String(longOpt, defaultValue, envDescription(description, envVar))
-		if err := viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)); err != nil {
-			bindFlagError(longOpt, err)
-		}
-		if err := viper.BindEnv(key, envVar); err != nil {
-			bindEnvError(envVar, err)
-		}
+		bindFlagError(longOpt, viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)))
+		bindEnvError(envVar, viper.BindEnv(key, envVar))
 		viper.SetDefault(key, defaultValue)
 	}
 
@@ -122,12 +102,8 @@ func init() {
 		)
 
 		rootCmd.PersistentFlags().Bool(longOpt, defaultValue, envDescription(description, envVar))
-		if err := viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)); err != nil {
-			bindFlagError(longOpt, err)
-		}
-		if err := viper.BindEnv(key, envVar); err != nil {
-			bindEnvError(envVar, err)
-		}
+		bindFlagError(longOpt, viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)))
+		bindEnvError(envVar, viper.BindEnv(key, envVar))
 		viper.SetDefault(key, defaultValue)
 	}
 
@@ -141,12 +117,8 @@ func init() {
 		)
 
 		rootCmd.PersistentFlags().String(longOpt, defaultValue, envDescription(description, envVar))
-		if err := viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)); err != nil {
-			bindFlagError(longOpt, err)
-		}
-		if err := viper.BindEnv(key, envVar); err != nil {
-			bindEnvError(envVar, err)
-		}
+		bindFlagError(longOpt, viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)))
+		bindEnvError(envVar, viper.BindEnv(key, envVar))
 		viper.SetDefault(key, defaultValue)
 	}
 
@@ -160,12 +132,8 @@ func init() {
 		)
 
 		rootCmd.PersistentFlags().Bool(longOpt, defaultValue, envDescription(description, envVar))
-		if err := viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)); err != nil {
-			bindFlagError(longOpt, err)
-		}
-		if err := viper.BindEnv(key, envVar); err != nil {
-			bindEnvError(envVar, err)
-		}
+		bindFlagError(longOpt, viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)))
+		bindEnvError(envVar, viper.BindEnv(key, envVar))
 		viper.SetDefault(key, defaultValue)
 	}
 
@@ -179,12 +147,8 @@ func init() {
 		)
 
 		rootCmd.PersistentFlags().String(longOpt, defaultValue, envDescription(description, envVar))
-		if err := viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)); err != nil {
-			bindFlagError(longOpt, err)
-		}
-		if err := viper.BindEnv(key, envVar); err != nil {
-			bindEnvError(envVar, err)
-		}
+		bindFlagError(longOpt, viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)))
+		bindEnvError(envVar, viper.BindEnv(key, envVar))
 		viper.SetDefault(key, defaultValue)
 	}
 
@@ -198,12 +162,8 @@ func init() {
 		)
 
 		rootCmd.PersistentFlags().String(longOpt, defaultValue, envDescription(description, envVar))
-		if err := viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)); err != nil {
-			bindFlagError(longOpt, err)
-		}
-		if err := viper.BindEnv(key, envVar); err != nil {
-			bindEnvError(envVar, err)
-		}
+		bindFlagError(longOpt, viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)))
+		bindEnvError(envVar, viper.BindEnv(key, envVar))
 		viper.SetDefault(key, defaultValue)
 	}
 
@@ -217,12 +177,8 @@ func init() {
 		)
 
 		rootCmd.PersistentFlags().String(longOpt, defaultValue, envDescription(description, envVar))
-		if err := viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)); err != nil {
-			bindFlagError(longOpt, err)
-		}
-		if err := viper.BindEnv(key, envVar); err != nil {
-			bindEnvError(envVar, err)
-		}
+		bindFlagError(longOpt, viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)))
+		bindEnvError(envVar, viper.BindEnv(key, envVar))
 		viper.SetDefault(key, defaultValue)
 	}
 
@@ -236,12 +192,8 @@ func init() {
 		)
 
 		rootCmd.PersistentFlags().String(longOpt, defaultValue, envDescription(description, envVar))
-		if err := viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)); err != nil {
-			bindFlagError(longOpt, err)
-		}
-		if err := viper.BindEnv(key, envVar); err != nil {
-			bindEnvError(envVar, err)
-		}
+		bindFlagError(longOpt, viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)))
+		bindEnvError(envVar, viper.BindEnv(key, envVar))
 		viper.SetDefault(key, defaultValue)
 	}
 
@@ -255,12 +207,8 @@ func init() {
 		)
 
 		rootCmd.PersistentFlags().String(longOpt, defaultValue, envDescription(description, envVar))
-		if err := viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)); err != nil {
-			bindFlagError(longOpt, err)
-		}
-		if err := viper.BindEnv(key, envVar); err != nil {
-			bindEnvError(envVar, err)
-		}
+		bindFlagError(longOpt, viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)))
+		bindEnvError(envVar, viper.BindEnv(key, envVar))
 		viper.SetDefault(key, defaultValue)
 	}
 
@@ -274,12 +222,8 @@ func init() {
 		defaultValue := defaults.CheckTarget
 
 		rootCmd.PersistentFlags().String(longOpt, defaultValue, envDescription(description, envVar))
-		if err := viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)); err != nil {
-			bindFlagError(longOpt, err)
-		}
-		if err := viper.BindEnv(key, envVar); err != nil {
-			bindEnvError(envVar, err)
-		}
+		bindFlagError(longOpt, viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)))
+		bindEnvError(envVar, viper.BindEnv(key, envVar))
 		viper.SetDefault(key, defaultValue)
 	}
 
@@ -293,12 +237,8 @@ func init() {
 		)
 
 		rootCmd.PersistentFlags().String(longOpt, defaultValue, envDescription(description, envVar))
-		if err := viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)); err != nil {
-			bindFlagError(longOpt, err)
-		}
-		if err := viper.BindEnv(key, envVar); err != nil {
-			bindEnvError(envVar, err)
-		}
+		bindFlagError(longOpt, viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)))
+		bindEnvError(envVar, viper.BindEnv(key, envVar))
 		viper.SetDefault(key, defaultValue)
 	}
 	{
@@ -311,12 +251,8 @@ func init() {
 		)
 
 		rootCmd.PersistentFlags().String(longOpt, defaultValue, envDescription(description, envVar))
-		if err := viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)); err != nil {
-			bindFlagError(longOpt, err)
-		}
-		if err := viper.BindEnv(key, envVar); err != nil {
-			bindEnvError(envVar, err)
-		}
+		bindFlagError(longOpt, viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)))
+		bindEnvError(envVar, viper.BindEnv(key, envVar))
 		viper.SetDefault(key, defaultValue)
 	}
 	{
@@ -329,12 +265,8 @@ func init() {
 		)
 
 		rootCmd.PersistentFlags().String(longOpt, defaultValue, envDescription(description, envVar))
-		if err := viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)); err != nil {
-			bindFlagError(longOpt, err)
-		}
-		if err := viper.BindEnv(key, envVar); err != nil {
-			bindEnvError(envVar, err)
-		}
+		bindFlagError(longOpt, viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)))
+		bindEnvError(envVar, viper.BindEnv(key, envVar))
 		viper.SetDefault(key, defaultValue)
 	}
 
@@ -354,12 +286,8 @@ func init() {
 		rootCmd.PersistentFlags().Bool(longOpt, defaultValue, envDescription(description, envVar))
 		flag := rootCmd.PersistentFlags().Lookup(longOpt)
 		flag.Hidden = true
-		if err := viper.BindPFlag(key, flag); err != nil {
-			bindFlagError(longOpt, err)
-		}
-		if err := viper.BindEnv(key, envVar); err != nil {
-			bindEnvError(envVar, err)
-		}
+		bindFlagError(longOpt, viper.BindPFlag(key, flag))
+		bindEnvError(envVar, viper.BindEnv(key, envVar))
 		viper.SetDefault(key, defaultValue)
 	}
 
@@ -375,12 +303,8 @@ func init() {
 		rootCmd.PersistentFlags().Bool(longOpt, defaultValue, envDescription(description, envVar))
 		flag := rootCmd.PersistentFlags().Lookup(longOpt)
 		flag.Hidden = true
-		if err := viper.BindPFlag(key, flag); err != nil {
-			bindFlagError(longOpt, err)
-		}
-		if err := viper.BindEnv(key, envVar); err != nil {
-			bindEnvError(envVar, err)
-		}
+		bindFlagError(longOpt, viper.BindPFlag(key, flag))
+		bindEnvError(envVar, viper.BindEnv(key, envVar))
 		viper.SetDefault(key, defaultValue)
 	}
 
@@ -396,12 +320,8 @@ func init() {
 		rootCmd.PersistentFlags().Bool(longOpt, defaultValue, envDescription(description, envVar))
 		flag := rootCmd.PersistentFlags().Lookup(longOpt)
 		flag.Hidden = true
-		if err := viper.BindPFlag(key, flag); err != nil {
-			bindFlagError(longOpt, err)
-		}
-		if err := viper.BindEnv(key, envVar); err != nil {
-			bindEnvError(envVar, err)
-		}
+		bindFlagError(longOpt, viper.BindPFlag(key, flag))
+		bindEnvError(envVar, viper.BindEnv(key, envVar))
 		viper.SetDefault(key, defaultValue)
 	}
 
@@ -417,12 +337,8 @@ func init() {
 		rootCmd.PersistentFlags().Bool(longOpt, defaultValue, envDescription(description, envVar))
 		flag := rootCmd.PersistentFlags().Lookup(longOpt)
 		flag.Hidden = true
-		if err := viper.BindPFlag(key, flag); err != nil {
-			bindFlagError(longOpt, err)
-		}
-		if err := viper.BindEnv(key, envVar); err != nil {
-			bindEnvError(envVar, err)
-		}
+		bindFlagError(longOpt, viper.BindPFlag(key, flag))
+		bindEnvError(envVar, viper.BindEnv(key, envVar))
 		viper.SetDefault(key, defaultValue)
 	}
 
@@ -438,12 +354,8 @@ func init() {
 		rootCmd.PersistentFlags().Bool(longOpt, defaultValue, envDescription(description, envVar))
 		flag := rootCmd.PersistentFlags().Lookup(longOpt)
 		flag.Hidden = true
-		if err := viper.BindPFlag(key, flag); err != nil {
-			bindFlagError(longOpt, err)
-		}
-		if err := viper.BindEnv(key, envVar); err != nil {
-			bindEnvError(envVar, err)
-		}
+		bindFlagError(longOpt, viper.BindPFlag(key, flag))
+		bindEnvError(envVar, viper.BindEnv(key, envVar))
 		viper.SetDefault(key, defaultValue)
 	}
 }

--- a/cmd/args_general.go
+++ b/cmd/args_general.go
@@ -28,12 +28,8 @@ func init() {
 		)
 
 		rootCmd.PersistentFlags().BoolP(longOpt, shortOpt, defaultValue, envDescription(description, envVar))
-		if err := viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)); err != nil {
-			bindFlagError(longOpt, err)
-		}
-		if err := viper.BindEnv(key, envVar); err != nil {
-			bindEnvError(envVar, err)
-		}
+		bindFlagError(longOpt, viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)))
+		bindEnvError(envVar, viper.BindEnv(key, envVar))
 		viper.SetDefault(key, defaultValue)
 	}
 
@@ -47,12 +43,8 @@ func init() {
 		)
 
 		rootCmd.PersistentFlags().String(longOpt, defaultValue, envDescription(description, envVar))
-		if err := viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)); err != nil {
-			bindFlagError(longOpt, err)
-		}
-		if err := viper.BindEnv(key, envVar); err != nil {
-			bindEnvError(envVar, err)
-		}
+		bindFlagError(longOpt, viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)))
+		bindEnvError(envVar, viper.BindEnv(key, envVar))
 		viper.SetDefault(key, defaultValue)
 	}
 
@@ -65,9 +57,7 @@ func init() {
 		)
 
 		rootCmd.PersistentFlags().Bool(longOpt, defaultValue, description)
-		if err := viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)); err != nil {
-			bindFlagError(longOpt, err)
-		}
+		bindFlagError(longOpt, viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)))
 		viper.SetDefault(key, defaultValue)
 	}
 
@@ -80,9 +70,7 @@ func init() {
 		)
 
 		rootCmd.PersistentFlags().String(longOpt, defaultValue, description)
-		if err := viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)); err != nil {
-			bindFlagError(longOpt, err)
-		}
+		bindFlagError(longOpt, viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)))
 		viper.SetDefault(key, defaultValue)
 	}
 }

--- a/cmd/args_kubernetes.go
+++ b/cmd/args_kubernetes.go
@@ -27,12 +27,8 @@ func init() {
 		)
 
 		rootCmd.PersistentFlags().String(longOpt, defaultValue, envDescription(description, envVar))
-		if err := viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)); err != nil {
-			bindFlagError(longOpt, err)
-		}
-		if err := viper.BindEnv(key, envVar); err != nil {
-			bindEnvError(envVar, err)
-		}
+		bindFlagError(longOpt, viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)))
+		bindEnvError(envVar, viper.BindEnv(key, envVar))
 		viper.SetDefault(key, defaultValue)
 	}
 
@@ -46,12 +42,8 @@ func init() {
 		)
 
 		rootCmd.PersistentFlags().String(longOpt, defaultValue, envDescription(description, envVar))
-		if err := viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)); err != nil {
-			bindFlagError(longOpt, err)
-		}
-		if err := viper.BindEnv(key, envVar); err != nil {
-			bindEnvError(envVar, err)
-		}
+		bindFlagError(longOpt, viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)))
+		bindEnvError(envVar, viper.BindEnv(key, envVar))
 		viper.SetDefault(key, defaultValue)
 	}
 
@@ -65,12 +57,8 @@ func init() {
 		)
 
 		rootCmd.PersistentFlags().String(longOpt, defaultValue, envDescription(description, envVar))
-		if err := viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)); err != nil {
-			bindFlagError(longOpt, err)
-		}
-		if err := viper.BindEnv(key, envVar); err != nil {
-			bindEnvError(envVar, err)
-		}
+		bindFlagError(longOpt, viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)))
+		bindEnvError(envVar, viper.BindEnv(key, envVar))
 		viper.SetDefault(key, defaultValue)
 	}
 
@@ -84,12 +72,8 @@ func init() {
 		)
 
 		rootCmd.PersistentFlags().String(longOpt, defaultValue, envDescription(description, envVar))
-		if err := viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)); err != nil {
-			bindFlagError(longOpt, err)
-		}
-		if err := viper.BindEnv(key, envVar); err != nil {
-			bindEnvError(envVar, err)
-		}
+		bindFlagError(longOpt, viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)))
+		bindEnvError(envVar, viper.BindEnv(key, envVar))
 		viper.SetDefault(key, defaultValue)
 	}
 
@@ -103,12 +87,8 @@ func init() {
 		)
 
 		rootCmd.PersistentFlags().String(longOpt, defaultValue, envDescription(description, envVar))
-		if err := viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)); err != nil {
-			bindFlagError(longOpt, err)
-		}
-		if err := viper.BindEnv(key, envVar); err != nil {
-			bindEnvError(envVar, err)
-		}
+		bindFlagError(longOpt, viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)))
+		bindEnvError(envVar, viper.BindEnv(key, envVar))
 		viper.SetDefault(key, defaultValue)
 	}
 
@@ -122,12 +102,8 @@ func init() {
 		)
 
 		rootCmd.PersistentFlags().String(longOpt, defaultValue, envDescription(description, envVar))
-		if err := viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)); err != nil {
-			bindFlagError(longOpt, err)
-		}
-		if err := viper.BindEnv(key, envVar); err != nil {
-			bindEnvError(envVar, err)
-		}
+		bindFlagError(longOpt, viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)))
+		bindEnvError(envVar, viper.BindEnv(key, envVar))
 		viper.SetDefault(key, defaultValue)
 	}
 
@@ -141,15 +117,14 @@ func init() {
 		)
 
 		rootCmd.PersistentFlags().Bool(longOpt, defaultValue, envDescription(description, envVar))
-		if err := viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)); err != nil {
-			bindFlagError(longOpt, err)
-		}
-		if err := viper.BindEnv(key, envVar); err != nil {
-			bindEnvError(envVar, err)
-		}
+		bindFlagError(longOpt, viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)))
+		bindEnvError(envVar, viper.BindEnv(key, envVar))
 		viper.SetDefault(key, defaultValue)
 	}
 
+	//
+	// kube-state-metrics
+	//
 	{
 		const (
 			key          = keys.K8SEnableKubeStateMetrics
@@ -160,72 +135,10 @@ func init() {
 		)
 
 		rootCmd.PersistentFlags().Bool(longOpt, defaultValue, envDescription(description, envVar))
-		if err := viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)); err != nil {
-			bindFlagError(longOpt, err)
-		}
-		if err := viper.BindEnv(key, envVar); err != nil {
-			bindEnvError(envVar, err)
-		}
+		bindFlagError(longOpt, viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)))
+		bindEnvError(envVar, viper.BindEnv(key, envVar))
 		viper.SetDefault(key, defaultValue)
 	}
-
-	{
-		const (
-			key          = keys.K8SKSMRequestMode
-			longOpt      = "k8s-ksm-request-mode"
-			envVar       = release.ENVPREFIX + "_K8S_KSM_REQUEST_MODE"
-			description  = "Kube-state-metrics request mode, proxy or direct"
-			defaultValue = defaults.K8SKSMRequestMode
-		)
-
-		rootCmd.PersistentFlags().String(longOpt, defaultValue, envDescription(description, envVar))
-		if err := viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)); err != nil {
-			bindFlagError(longOpt, err)
-		}
-		if err := viper.BindEnv(key, envVar); err != nil {
-			bindEnvError(envVar, err)
-		}
-		viper.SetDefault(key, defaultValue)
-	}
-
-	{
-		const (
-			key          = keys.K8SKSMMetricsPortName
-			longOpt      = "k8s-ksm-metrics-port-name"
-			envVar       = release.ENVPREFIX + "_K8S_KSM_METRICS_PORT_NAME"
-			description  = "Kube-state-metrics metrics port name"
-			defaultValue = defaults.K8SKSMMetricsPortName
-		)
-
-		rootCmd.PersistentFlags().String(longOpt, defaultValue, envDescription(description, envVar))
-		if err := viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)); err != nil {
-			bindFlagError(longOpt, err)
-		}
-		if err := viper.BindEnv(key, envVar); err != nil {
-			bindEnvError(envVar, err)
-		}
-		viper.SetDefault(key, defaultValue)
-	}
-
-	{
-		const (
-			key          = keys.K8SKSMTelemetryPortName
-			longOpt      = "k8s-ksm-telemetry-port-name"
-			envVar       = release.ENVPREFIX + "_K8S_KSM_TELEMETRY_PORT_NAME"
-			description  = "Kube-state-metrics telemetry port name"
-			defaultValue = defaults.K8SKSMTelemetryPortName
-		)
-
-		rootCmd.PersistentFlags().String(longOpt, defaultValue, envDescription(description, envVar))
-		if err := viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)); err != nil {
-			bindFlagError(longOpt, err)
-		}
-		if err := viper.BindEnv(key, envVar); err != nil {
-			bindEnvError(envVar, err)
-		}
-		viper.SetDefault(key, defaultValue)
-	}
-
 	{
 		const (
 			key          = keys.K8SKSMFieldSelectorQuery
@@ -236,12 +149,69 @@ func init() {
 		)
 
 		rootCmd.PersistentFlags().String(longOpt, defaultValue, envDescription(description, envVar))
-		if err := viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)); err != nil {
-			bindFlagError(longOpt, err)
-		}
-		if err := viper.BindEnv(key, envVar); err != nil {
-			bindEnvError(envVar, err)
-		}
+		bindFlagError(longOpt, viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)))
+		bindEnvError(envVar, viper.BindEnv(key, envVar))
+		viper.SetDefault(key, defaultValue)
+	}
+	{
+		const (
+			key          = keys.K8SKSMMetricsPort
+			longOpt      = "k8s-ksm-metrics-port"
+			envVar       = release.ENVPREFIX + "_K8S_KSM_METRICS_PORT"
+			description  = "Kube-state-metrics metrics port"
+			defaultValue = defaults.K8SKSMMetricsPort
+		)
+
+		rootCmd.PersistentFlags().String(longOpt, defaultValue, envDescription(description, envVar))
+		bindFlagError(longOpt, viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)))
+		bindEnvError(envVar, viper.BindEnv(key, envVar))
+		viper.SetDefault(key, defaultValue)
+	}
+	{
+		const (
+			key          = keys.K8SKSMMetricsPortName
+			longOpt      = "k8s-ksm-metrics-port-name"
+			envVar       = release.ENVPREFIX + "_K8S_KSM_METRICS_PORT_NAME"
+			description  = "Kube-state-metrics metrics port name"
+			defaultValue = defaults.K8SKSMMetricsPortName
+		)
+
+		rootCmd.PersistentFlags().String(longOpt, defaultValue, envDescription(description, envVar))
+		bindFlagError(longOpt, viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)))
+		bindEnvError(envVar, viper.BindEnv(key, envVar))
+		viper.SetDefault(key, defaultValue)
+	}
+
+	{ // DEPRECATED
+		const (
+			key          = keys.K8SKSMTelemetryPortName
+			longOpt      = "k8s-ksm-telemetry-port-name"
+			envVar       = release.ENVPREFIX + "_K8S_KSM_TELEMETRY_PORT_NAME"
+			description  = "Kube-state-metrics telemetry port name"
+			defaultValue = "" //don't collect by default, we don't use them. defaults.K8SKSMTelemetryPortName
+		)
+
+		rootCmd.PersistentFlags().String(longOpt, defaultValue, envDescription(description, envVar))
+		flag := rootCmd.PersistentFlags().Lookup(longOpt)
+		flag.Hidden = true
+		bindFlagError(longOpt, viper.BindPFlag(key, flag))
+		bindEnvError(envVar, viper.BindEnv(key, envVar))
+		viper.SetDefault(key, defaultValue)
+	}
+	{ // DEPRECATED
+		const (
+			key          = keys.K8SKSMRequestMode
+			longOpt      = "k8s-ksm-request-mode"
+			envVar       = release.ENVPREFIX + "_K8S_KSM_REQUEST_MODE"
+			description  = "Kube-state-metrics request mode, proxy or direct"
+			defaultValue = defaults.K8SKSMRequestMode
+		)
+
+		rootCmd.PersistentFlags().String(longOpt, defaultValue, envDescription(description, envVar))
+		flag := rootCmd.PersistentFlags().Lookup(longOpt)
+		flag.Hidden = true
+		bindFlagError(longOpt, viper.BindPFlag(key, flag))
+		bindEnvError(envVar, viper.BindEnv(key, envVar))
 		viper.SetDefault(key, defaultValue)
 	}
 
@@ -255,17 +225,12 @@ func init() {
 		)
 
 		rootCmd.PersistentFlags().Bool(longOpt, defaultValue, envDescription(description, envVar))
-		if err := viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)); err != nil {
-			bindFlagError(longOpt, err)
-		}
-		if err := viper.BindEnv(key, envVar); err != nil {
-			bindEnvError(envVar, err)
-		}
+		bindFlagError(longOpt, viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)))
+		bindEnvError(envVar, viper.BindEnv(key, envVar))
 		viper.SetDefault(key, defaultValue)
 	}
 
-	{
-		// This is deprecated, it is a NOOP and will be removed from a future release
+	{ // DEPRECATED
 		const (
 			key          = keys.K8SEnableMetricsServer
 			longOpt      = "k8s-enable-metrics-server"
@@ -275,12 +240,10 @@ func init() {
 		)
 
 		rootCmd.PersistentFlags().Bool(longOpt, defaultValue, envDescription(description, envVar))
-		if err := viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)); err != nil {
-			bindFlagError(longOpt, err)
-		}
-		if err := viper.BindEnv(key, envVar); err != nil {
-			bindEnvError(envVar, err)
-		}
+		flag := rootCmd.PersistentFlags().Lookup(longOpt)
+		flag.Hidden = true
+		bindFlagError(longOpt, viper.BindPFlag(key, flag))
+		bindEnvError(envVar, viper.BindEnv(key, envVar))
 		viper.SetDefault(key, defaultValue)
 	}
 
@@ -294,12 +257,8 @@ func init() {
 		)
 
 		rootCmd.PersistentFlags().Bool(longOpt, defaultValue, envDescription(description, envVar))
-		if err := viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)); err != nil {
-			bindFlagError(longOpt, err)
-		}
-		if err := viper.BindEnv(key, envVar); err != nil {
-			bindEnvError(envVar, err)
-		}
+		bindFlagError(longOpt, viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)))
+		bindEnvError(envVar, viper.BindEnv(key, envVar))
 		viper.SetDefault(key, defaultValue)
 	}
 
@@ -313,12 +272,8 @@ func init() {
 		)
 
 		rootCmd.PersistentFlags().String(longOpt, defaultValue, envDescription(description, envVar))
-		if err := viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)); err != nil {
-			bindFlagError(longOpt, err)
-		}
-		if err := viper.BindEnv(key, envVar); err != nil {
-			bindEnvError(envVar, err)
-		}
+		bindFlagError(longOpt, viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)))
+		bindEnvError(envVar, viper.BindEnv(key, envVar))
 		viper.SetDefault(key, defaultValue)
 	}
 
@@ -332,12 +287,8 @@ func init() {
 		)
 
 		rootCmd.PersistentFlags().Bool(longOpt, defaultValue, envDescription(description, envVar))
-		if err := viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)); err != nil {
-			bindFlagError(longOpt, err)
-		}
-		if err := viper.BindEnv(key, envVar); err != nil {
-			bindEnvError(envVar, err)
-		}
+		bindFlagError(longOpt, viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)))
+		bindEnvError(envVar, viper.BindEnv(key, envVar))
 		viper.SetDefault(key, defaultValue)
 	}
 
@@ -351,12 +302,8 @@ func init() {
 		)
 
 		rootCmd.PersistentFlags().Bool(longOpt, defaultValue, envDescription(description, envVar))
-		if err := viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)); err != nil {
-			bindFlagError(longOpt, err)
-		}
-		if err := viper.BindEnv(key, envVar); err != nil {
-			bindEnvError(envVar, err)
-		}
+		bindFlagError(longOpt, viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)))
+		bindEnvError(envVar, viper.BindEnv(key, envVar))
 		viper.SetDefault(key, defaultValue)
 	}
 
@@ -370,12 +317,8 @@ func init() {
 		)
 
 		rootCmd.PersistentFlags().Bool(longOpt, defaultValue, envDescription(description, envVar))
-		if err := viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)); err != nil {
-			bindFlagError(longOpt, err)
-		}
-		if err := viper.BindEnv(key, envVar); err != nil {
-			bindEnvError(envVar, err)
-		}
+		bindFlagError(longOpt, viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)))
+		bindEnvError(envVar, viper.BindEnv(key, envVar))
 		viper.SetDefault(key, defaultValue)
 	}
 
@@ -389,12 +332,8 @@ func init() {
 		)
 
 		rootCmd.PersistentFlags().Bool(longOpt, defaultValue, envDescription(description, envVar))
-		if err := viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)); err != nil {
-			bindFlagError(longOpt, err)
-		}
-		if err := viper.BindEnv(key, envVar); err != nil {
-			bindEnvError(envVar, err)
-		}
+		bindFlagError(longOpt, viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)))
+		bindEnvError(envVar, viper.BindEnv(key, envVar))
 		viper.SetDefault(key, defaultValue)
 	}
 	{
@@ -407,12 +346,8 @@ func init() {
 		)
 
 		rootCmd.PersistentFlags().String(longOpt, defaultValue, envDescription(description, envVar))
-		if err := viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)); err != nil {
-			bindFlagError(longOpt, err)
-		}
-		if err := viper.BindEnv(key, envVar); err != nil {
-			bindEnvError(envVar, err)
-		}
+		bindFlagError(longOpt, viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)))
+		bindEnvError(envVar, viper.BindEnv(key, envVar))
 		viper.SetDefault(key, defaultValue)
 	}
 
@@ -426,12 +361,8 @@ func init() {
 		)
 
 		rootCmd.PersistentFlags().Bool(longOpt, defaultValue, envDescription(description, envVar))
-		if err := viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)); err != nil {
-			bindFlagError(longOpt, err)
-		}
-		if err := viper.BindEnv(key, envVar); err != nil {
-			bindEnvError(envVar, err)
-		}
+		bindFlagError(longOpt, viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)))
+		bindEnvError(envVar, viper.BindEnv(key, envVar))
 		viper.SetDefault(key, defaultValue)
 	}
 
@@ -445,12 +376,8 @@ func init() {
 		)
 
 		rootCmd.PersistentFlags().String(longOpt, defaultValue, envDescription(description, envVar))
-		if err := viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)); err != nil {
-			bindFlagError(longOpt, err)
-		}
-		if err := viper.BindEnv(key, envVar); err != nil {
-			bindEnvError(envVar, err)
-		}
+		bindFlagError(longOpt, viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)))
+		bindEnvError(envVar, viper.BindEnv(key, envVar))
 		viper.SetDefault(key, defaultValue)
 	}
 
@@ -464,12 +391,8 @@ func init() {
 		)
 
 		rootCmd.PersistentFlags().String(longOpt, defaultValue, envDescription(description, envVar))
-		if err := viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)); err != nil {
-			bindFlagError(longOpt, err)
-		}
-		if err := viper.BindEnv(key, envVar); err != nil {
-			bindEnvError(envVar, err)
-		}
+		bindFlagError(longOpt, viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)))
+		bindEnvError(envVar, viper.BindEnv(key, envVar))
 		viper.SetDefault(key, defaultValue)
 	}
 
@@ -483,12 +406,8 @@ func init() {
 		)
 
 		rootCmd.PersistentFlags().Bool(longOpt, defaultValue, envDescription(description, envVar))
-		if err := viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)); err != nil {
-			bindFlagError(longOpt, err)
-		}
-		if err := viper.BindEnv(key, envVar); err != nil {
-			bindEnvError(envVar, err)
-		}
+		bindFlagError(longOpt, viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)))
+		bindEnvError(envVar, viper.BindEnv(key, envVar))
 		viper.SetDefault(key, defaultValue)
 	}
 
@@ -502,12 +421,8 @@ func init() {
 		defaultValue := uint(defaults.K8SNodePoolSize)
 
 		rootCmd.PersistentFlags().Uint(longOpt, defaultValue, envDescription(description, envVar))
-		if err := viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)); err != nil {
-			bindFlagError(longOpt, err)
-		}
-		if err := viper.BindEnv(key, envVar); err != nil {
-			bindEnvError(envVar, err)
-		}
+		bindFlagError(longOpt, viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)))
+		bindEnvError(envVar, viper.BindEnv(key, envVar))
 		viper.SetDefault(key, defaultValue)
 	}
 
@@ -521,13 +436,23 @@ func init() {
 		)
 
 		rootCmd.PersistentFlags().String(longOpt, defaultValue, envDescription(description, envVar))
-		if err := viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)); err != nil {
-			bindFlagError(longOpt, err)
-		}
-		if err := viper.BindEnv(key, envVar); err != nil {
-			bindEnvError(envVar, err)
-		}
+		bindFlagError(longOpt, viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)))
+		bindEnvError(envVar, viper.BindEnv(key, envVar))
 		viper.SetDefault(key, defaultValue)
 	}
 
+	{
+		const (
+			key          = keys.K8SDynamicCollectorFile
+			longOpt      = "k8s-dynamic-collector-file"
+			envVar       = release.ENVPREFIX + "_K8S_DYNAMIC_COLLECTOR_FILE"
+			description  = "Kubernetes dynamic collectors configuration file"
+			defaultValue = defaults.K8SDynamicCollectorFile
+		)
+
+		rootCmd.PersistentFlags().String(longOpt, defaultValue, envDescription(description, envVar))
+		bindFlagError(longOpt, viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(longOpt)))
+		bindEnvError(envVar, viper.BindEnv(key, envVar))
+		viper.SetDefault(key, defaultValue)
+	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,7 +11,6 @@ import (
 	stdlog "log"
 	"os"
 	"runtime"
-	"time"
 
 	"github.com/circonus-labs/circonus-kubernetes-agent/internal/agent"
 	"github.com/circonus-labs/circonus-kubernetes-agent/internal/config"
@@ -99,7 +98,8 @@ func envDescription(desc, env string) string {
 }
 
 func init() {
-	zerolog.TimeFieldFormat = time.RFC3339Nano
+	// zerolog.TimeFieldFormat = time.RFC3339Nano
+	zerolog.TimeFieldFormat = zerolog.TimeFormatUnix
 	zerolog.SetGlobalLevel(zerolog.InfoLevel)
 	zlog := zerolog.New(zerolog.SyncWriter(os.Stderr)).With().Timestamp().Logger()
 	log.Logger = zlog

--- a/deploy/custom/configuration.yaml
+++ b/deploy/custom/configuration.yaml
@@ -49,7 +49,8 @@
       ## Use a static target to ensure that the agent can find the check
       ## the next time the pod starts. Otherwise, the pod's hostname will
       ## be used and a new check would be created each time the pod is
-      ## created when create is enabled.
+      ## created when create is enabled. The kubernetes-name will be
+      ## used if check-target is not set.
       circonus-check-target: ""
       ## set a custom display title for the check when it is created
       #circonus-check-title: ""
@@ -66,14 +67,13 @@
       kubernetes-enable-events: "true"
       ## collect metrics from kube-state-metrics if running - default is enabled for dashboard
       kubernetes-enable-kube-state-metrics: "true"
-      ## kube-state-metrics reqeust mode (direct or proxy) proxy goes through api-server, direct uses the service endpoint ip
-      kubernetes-ksm-request-mode: "direct"
-      ## kube-state-metrics metrics port name, default from https://github.com/kubernetes/kube-state-metrics/blob/master/examples/standard/service.yaml
-      kubernetes-ksm-metrics-port-name: "http-metrics"
-      ## kube-state-metrics telemetry port name, default from https://github.com/kubernetes/kube-state-metrics/blob/master/examples/standard/service.yaml
-      kubernetes-ksm-telemetry-port-name: "telemetry"
       ## kube-state-metrics fieldSelector query, default from https://github.com/kubernetes/kube-state-metrics/blob/master/examples/standard/service.yaml
       kubernetes-ksm-field-selector-query: "metadata.name=kube-state-metrics"
+      ## kube-state-metrics metrics port, no default, service endpoint ports will be used if not set
+      kubernetes-ksm-metrics-port: ""
+      ## kube-state-metrics metrics port name, default from https://github.com/kubernetes/kube-state-metrics/blob/master/examples/standard/service.yaml
+      ## if using helm or some other tool, look at the configuration to see if the port is named differently in the service endpoint...
+      kubernetes-ksm-metrics-port-name: "http-metrics"
       ## collect metrics from api-server - default is enabled for dashboard
       kubernetes-enable-api-server: "true"
       ## collect node metrics - default is enabled for dashboard
@@ -104,6 +104,30 @@
       ## api request timelimit
       #kubernetes-api-timelimit: "10s"
       ##
+      ## dynamic collectors (see readme in github repository)
+      ##
+      dynamic-collectors.yaml: |
+        collectors:
+          - name: "" 
+            disable: true
+            type: "" 
+            schema: ""
+            selectors:
+              label: "" 
+              field: ""
+            control:
+              annotation: ""
+              label: ""
+              value: ""
+            metric_port:
+              annotation: ""
+              label: ""
+              value: ""
+            metric_path:
+              annotation: ""
+              label: ""
+              value: ""
+      ##
       ## Metric filters control which metrics are passed on by the broker
       ## NOTE: This list is applied to the check every time the agent pod starts.
       ##       Updates through any other method will be overwritten by this list.
@@ -125,7 +149,7 @@
             ["allow", "^kube_job_status_failed$", "health"],
             ["allow", "^kube_persistentvolume_status_phase$", "health"],
             ["allow", "^kube_deployment_status_replicas_unavailable$", "deployments"],
-            ["allow", "^kube_hpa_spec_(min|max)_replicas", "scale"],
+            ["allow", "^kube_hpa_(spec_max|status_current)_replicas$", "scale"],
             ["allow", "^kube_pod_start_time$", "pods"],
             ["allow", "^kube_pod_status_condition$", "pods"],
             ["allow", "^(kube_)?pod_status_phase(_count)?$", "tags", "and(or(phase:Running,phase:Pending,phase:Failed,phase:Succeeded))", "pods"],

--- a/deploy/custom/deployment.yaml
+++ b/deploy/custom/deployment.yaml
@@ -5,26 +5,26 @@
     name: circonus-kubernetes-agent
     labels:
       app.kubernetes.io/name: circonus-kubernetes-agent
-      app.kubernetes.io/version: v0.10.4
+      app.kubernetes.io/version: v0.11.0
   spec:
     selector:
       matchLabels:
         app.kubernetes.io/name: circonus-kubernetes-agent
-        app.kubernetes.io/version: v0.10.4
+        app.kubernetes.io/version: v0.11.0
     replicas: 1
     template:
       metadata:
         name: circonus-kubernetes-agent
         labels:
           app.kubernetes.io/name: circonus-kubernetes-agent
-          app.kubernetes.io/version: v0.10.4
+          app.kubernetes.io/version: v0.11.0
       spec:
         serviceAccountName: circonus-kubernetes-agent
         containers:
           - name: circonus-kubernetes-agent
-            image: circonuslabs/circonus-kubernetes-agent:v0.10.4
+            image: circonuslabs/circonus-kubernetes-agent:v0.11.0
             ## for ARM64, remove line above and uncomment line below
-            #image: circonuslabs/circonus-kubernetes-agent-arm64:v0.10.4
+            #image: circonuslabs/circonus-kubernetes-agent-arm64:v0.11.0
             command: ["/circonus-kubernetes-agentd"]
             args: 
               #- --debug
@@ -146,26 +146,21 @@
                   configMapKeyRef:
                     name: cka-config-v1
                     key: kubernetes-enable-kube-state-metrics
-              - name: CKA_K8S_KSM_REQUEST_MODE
-                valueFrom:
-                  configMapKeyRef:
-                    name: cka-config-v1
-                    key: kubernetes-ksm-request-mode
-              - name: CKA_K8S_KSM_METRICS_PORT_NAME
-                valueFrom:
-                  configMapKeyRef:
-                    name: cka-config-v1
-                    key: kubernetes-ksm-metrics-port-name
-              - name: CKA_K8S_KSM_TELEMETRY_PORT_NAME
-                valueFrom:
-                  configMapKeyRef:
-                    name: cka-config-v1
-                    key: kubernetes-ksm-telemetry-port-name
               - name: CKA_K8S_KSM_FIELD_SELECTOR_QUERY
                 valueFrom:
                   configMapKeyRef:
                     name: cka-config-v1
                     key: kubernetes-ksm-field-selector-query
+              - name: CKA_K8S_KSM_METRICS_PORT
+                valueFrom:
+                  configMapKeyRef:
+                    name: cka-config-v1
+                    key: kubernetes-ksm-metrics-port
+              - name: CKA_K8S_KSM_METRICS_PORT_NAME
+                valueFrom:
+                  configMapKeyRef:
+                    name: cka-config-v1
+                    key: kubernetes-ksm-metrics-port-name
               - name: CKA_K8S_ENABLE_API_SERVER
                 valueFrom:
                   configMapKeyRef:
@@ -273,3 +268,5 @@
                   path: default-alerts.json
                 - key: custom-rules.json
                   path: custom-rules.json
+                - key: dynamic-collectors.yaml
+                  path: dynamic-collectors.yaml

--- a/internal/circonus/alerting.go
+++ b/internal/circonus/alerting.go
@@ -497,7 +497,8 @@ func defaultRules() (map[string]apiclient.RuleSet, error) {
                 "severity": 1,
                 "wait": 0,
                 "windowing_duration": 900,
-                "windowing_function": "average",
+				"windowing_function": "average",
+				"windowing_min_duration": 900,
                 "value": "75"
             }
         ]    
@@ -599,7 +600,7 @@ func defaultRules() (map[string]apiclient.RuleSet, error) {
 				"wait": 0,
 				"windowing_duration": 300,
 				"windowing_function": "average",
-				"windowing_min_duration": 0,
+				"windowing_min_duration": 300,
                 "value": "0.99"
             }
         ]
@@ -675,7 +676,8 @@ func defaultRules() (map[string]apiclient.RuleSet, error) {
                 "severity": 1,
                 "wait": 0,
                 "windowing_duration": 900,
-                "windowing_function": "average",
+				"windowing_function": "average",
+				"windowing_min_duration": 900,
                 "value": "0.99"
             }
         ]        

--- a/internal/circonus/check.go
+++ b/internal/circonus/check.go
@@ -416,7 +416,6 @@ func (c *Check) defaultFilters() [][]string {
 	defaultMetricFiltersData := []byte(`
 {
     "metric_filters": [
-	["allow", "^coredns_plugin_enabled$", "tags", "and(collector:dynamic)"],
     ["allow", "^[rt]x$", "tags", "and(resource:network,or(units:bytes,units:errors),not(container_name:*),not(sys_container:*))", "utilization"],
     ["allow", "^(used|capacity)$", "tags", "and(or(units:bytes,units:percent),or(resource:memory,resource:fs,volume_name:*),not(container_name:*),not(sys_container:*))", "utilization"],
 	["allow", "^usage(Milli|Nano)Cores$", "tags", "and(not(container_name:*),not(sys_container:*))", "utilization"],

--- a/internal/circonus/check.go
+++ b/internal/circonus/check.go
@@ -416,6 +416,7 @@ func (c *Check) defaultFilters() [][]string {
 	defaultMetricFiltersData := []byte(`
 {
     "metric_filters": [
+	["allow", "^coredns_plugin_enabled$", "tags", "and(collector:dynamic)"],
     ["allow", "^[rt]x$", "tags", "and(resource:network,or(units:bytes,units:errors),not(container_name:*),not(sys_container:*))", "utilization"],
     ["allow", "^(used|capacity)$", "tags", "and(or(units:bytes,units:percent),or(resource:memory,resource:fs,volume_name:*),not(container_name:*),not(sys_container:*))", "utilization"],
 	["allow", "^usage(Milli|Nano)Cores$", "tags", "and(not(container_name:*),not(sys_container:*))", "utilization"],
@@ -431,7 +432,7 @@ func (c *Check) defaultFilters() [][]string {
     ["allow", "^kube_job_status_failed$", "health"],
     ["allow", "^kube_persistentvolume_status_phase$", "health"],
 	["allow", "^kube_deployment_status_replicas_unavailable$", "deployments"],
-    ["allow", "^kube_hpa_spec_(min|max)_replicas", "scale"],
+    ["allow", "^kube_hpa_(spec_max|status_current)_replicas$", "scale"],
     ["allow", "^kube_pod_start_time$", "pods"],
     ["allow", "^kube_pod_status_condition$", "pods"],
     ["allow", "^(kube_)?pod_status_phase(_count)?$", "tags", "and(or(phase:Running,phase:Pending,phase:Failed,phase:Succeeded))", "pods"],

--- a/internal/circonus/metrics.go
+++ b/internal/circonus/metrics.go
@@ -8,6 +8,7 @@ package circonus
 import (
 	"errors"
 	"fmt"
+	"math"
 	"regexp"
 	"strings"
 	"time"
@@ -212,6 +213,15 @@ func (c *Check) QueueMetricSample(
 
 	if !metricTypeRx.MatchString(metricType) {
 		return fmt.Errorf("unrecognized circonus metric type (%s)", metricType)
+	}
+
+	if metricType == "n" && math.IsNaN(value.(float64)) {
+		c.log.Warn().
+			Str("metric_name", metricName).
+			Strs("stream_tags", streamTagList).
+			Interface("value", value).
+			Msg("is NaN, skipping")
+		return fmt.Errorf("metric value is NaN")
 	}
 
 	val := value

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -34,9 +34,8 @@ type Cluster struct {
 	BearerTokenFile        string `mapstructure:"bearer_token_file" json:"bearer_token_file" toml:"bearer_token_file" yaml:"bearer_token_file"`
 	EnableEvents           bool   `mapstructure:"enable_events" json:"enable_events" toml:"enable_events" yaml:"enable_events"`
 	EnableKubeStateMetrics bool   `mapstructure:"enable_kube_state_metrics" json:"enable_kube_state_metrics" toml:"enable_kube_state_metrics" yaml:"enable_kube_state_metrics"`
-	KSMRequestMode         string `mapstructure:"ksm_request_mode" json:"ksm_request_mode" toml:"ksm_request_mode" yaml:"ksm_request_mode"`
+	KSMMetricsPort         string `mapstructure:"ksm_metrics_port" json:"ksm_metrics_port" toml:"ksm_metrics_port" yaml:"ksm_metrics_port"`
 	KSMMetricsPortName     string `mapstructure:"ksm_metrics_port_name" json:"ksm_metrics_port_name" toml:"ksm_metrics_port_name" yaml:"ksm_metrics_port_name"`
-	KSMTelemetryPortName   string `mapstructure:"ksm_telemetry_port_name" json:"ksm_telemetry_port_name" toml:"ksm_telemetry_port_name" yaml:"ksm_telemetry_port_name"`
 	KSMFieldSelectorQuery  string `mapstructure:"ksm_field_selector_query" json:"ksm_field_selector_query" toml:"ksm_field_selector_query" yaml:"ksm_field_selector_query"`
 	EnableAPIServer        bool   `mapstructure:"enable_api_server" json:"enable_api_server" toml:"enable_api_server" yaml:"enable_metrics_server"`
 	EnableNodes            bool   `mapstructure:"enable_nodes" json:"enable_nodes" toml:"enable_nodes" yaml:"enable_nodes"`
@@ -55,6 +54,10 @@ type Cluster struct {
 	URL                    string `mapstructure:"api_url" json:"api_url" toml:"api_url" yaml:"api_url"`
 	CAFile                 string `mapstructure:"api_ca_file" json:"api_ca_file" toml:"api_ca_file" yaml:"api_ca_file"`
 	APITimelimit           string `mapstructure:"api_timelimit" json:"api_timelimit" toml:"api_timelimit" yaml:"api_timelimit"`
+	DynamicCollectorFile   string `mapstructure:"dynamic_collector_file" json:"dynamic_collector_file" yaml:"dynamic_collector_file"`
+	// DEPRECATED
+	KSMRequestMode       string `mapstructure:"ksm_request_mode" json:"ksm_request_mode" toml:"ksm_request_mode" yaml:"ksm_request_mode"`
+	KSMTelemetryPortName string `mapstructure:"ksm_telemetry_port_name" json:"ksm_telemetry_port_name" toml:"ksm_telemetry_port_name" yaml:"ksm_telemetry_port_name"`
 }
 
 // LabelFilters defines labels to include and exclude

--- a/internal/config/defaults/defaults.go
+++ b/internal/config/defaults/defaults.go
@@ -74,10 +74,11 @@ const (
 	K8SBearerTokenFile        = "/var/run/secrets/kubernetes.io/serviceaccount/token" //nolint:gosec // https://kubernetes.io/docs/tasks/access-application-cluster/access-cluster/#accessing-the-api-from-a-pod
 	K8SEnableEvents           = true                                                  // dashboard
 	K8SEnableKubeStateMetrics = true                                                  // dashobard
-	K8SKSMRequestMode         = "direct"                                              // 'direct' or 'proxy' modes supported
-	K8SKSMMetricsPortName     = "http-metrics"                                        // default from 'standard' service deployment, https://github.com/kubernetes/kube-state-metrics/blob/master/examples/standard/service.yaml#L11
-	K8SKSMTelemetryPortName   = "telemetry"                                           // default from 'standard' service deployment, https://github.com/kubernetes/kube-state-metrics/blob/master/examples/standard/service.yaml#L11
 	K8SKSMFieldSelectorQuery  = "metadata.name=kube-state-metrics"                    // default from 'standard' service deployment, https://github.com/kubernetes/kube-state-metrics/blob/master/examples/standard/service.yaml#L19
+	K8SKSMMetricsPort         = ""                                                    // no default, pulled from endpoint for service
+	K8SKSMMetricsPortName     = "http-metrics"                                        // default from 'standard' service deployment, https://github.com/kubernetes/kube-state-metrics/blob/master/examples/standard/service.yaml#L11
+	K8SKSMRequestMode         = "direct"                                              // DEPRECATED - 'direct' or 'proxy' modes supported
+	K8SKSMTelemetryPortName   = "telemetry"                                           // DEPRECATED - default from 'standard' service deployment, https://github.com/kubernetes/kube-state-metrics/blob/master/examples/standard/service.yaml#L11
 	K8SEnableAPIServer        = true                                                  // dashboard
 	K8SEnableMetricsServer    = false                                                 // deprecated
 	K8SEnableNodes            = true                                                  // dashboard
@@ -91,7 +92,8 @@ const (
 	K8SPodLabelKey            = ""                                                    // blank=all
 	K8SPodLabelVal            = ""                                                    // blank=all
 	K8SIncludeContainers      = false                                                 // not needed by dashboard
-	K8SAPITimelimit           = "10s"
+	K8SAPITimelimit           = "10s"                                                 // default timeout
+	K8SDynamicCollectorFile   = "/ck8sa/dynamic-collectors.json"                      // assumes running in a pod, ConfigMap mounted volume
 )
 
 var (

--- a/internal/config/keys/keys.go
+++ b/internal/config/keys/keys.go
@@ -161,16 +161,17 @@ const (
 
 	// K8SEnableKubeStateMetrics enable kube-state-metrics
 	K8SEnableKubeStateMetrics = "kubernetes.enable_kube_state_metrics"
-	K8SKSMRequestMode         = "kubernetes.ksm_request_mode"
-	K8SKSMMetricsPortName     = "kubernetes.ksm_metrics_port_name"
-	K8SKSMTelemetryPortName   = "kubernetes.ksm_telemetry_port_name"
 	K8SKSMFieldSelectorQuery  = "kubernetes.ksm_field_selector_query"
+	K8SKSMMetricsPort         = "kubernetes.ksm_metrics_port"
+	K8SKSMMetricsPortName     = "kubernetes.ksm_metrics_port_name"
+	K8SKSMTelemetryPortName   = "kubernetes.ksm_telemetry_port_name" // DEPRECATED
+	K8SKSMRequestMode         = "kubernetes.ksm_request_mode"        // DEPRECATED
 
 	// K8SEnableAPIServer enable api-server
 	K8SEnableAPIServer = "kubernetes.enable_api_server"
 
 	// K8SEnableMetricsServer DEPRECATED, to be removed in future release
-	K8SEnableMetricsServer = "kubernetes.enable_metrics_server"
+	K8SEnableMetricsServer = "kubernetes.enable_metrics_server" // DEPRECATED
 
 	// K8SIncludePods include pod metrics
 	// NOTE: requires K8SEnableNodes and K8SEnableNodeSummary
@@ -195,6 +196,9 @@ const (
 
 	// K8SAPITimelimit amount of time to wait for a complete response from api-server
 	K8SAPITimelimit = "kubernetes.api_timelimit"
+
+	// K8SDynamicCollectorFile defines the file containing the dynamic collectors configuration
+	K8SDynamicCollectorFile = "kubernetes.dynamic_collector_file"
 
 	//
 	// Kubernetes clusters (multiple, use either kubernetes or clusters, not both)

--- a/internal/dc/dc.go
+++ b/internal/dc/dc.go
@@ -1,0 +1,655 @@
+// Copyright © 2020 Circonus, Inc. <support@circonus.com>
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+
+// Package dc is the dynamic collector
+package dc
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	cgm "github.com/circonus-labs/circonus-gometrics/v3"
+	"github.com/circonus-labs/circonus-kubernetes-agent/internal/circonus"
+	"github.com/circonus-labs/circonus-kubernetes-agent/internal/config"
+	"github.com/circonus-labs/circonus-kubernetes-agent/internal/k8s"
+	"github.com/circonus-labs/circonus-kubernetes-agent/internal/promtext"
+	"github.com/circonus-labs/circonus-kubernetes-agent/internal/release"
+	"github.com/prometheus/common/expfmt"
+	"github.com/rs/zerolog"
+	"gopkg.in/yaml.v2"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type DC struct {
+	config     *config.Cluster
+	check      *circonus.Check
+	collectors []Collector `yaml:"collectors"`
+	log        zerolog.Logger
+	running    bool
+	sync.Mutex
+	ts *time.Time
+}
+
+type Collectors struct {
+	Collectors []Collector `yaml:"collectors"`
+}
+
+type Collector struct {
+	Name       string     `yaml:"name"`
+	Disable    bool       `yaml:"disable"`
+	Type       string     `yaml:"type"`
+	Schema     string     `yaml:"schema"`
+	Selectors  Selectors  `yaml:"selectors"`
+	Control    Control    `yaml:"control"`
+	MetricPort MetricPort `yaml:"metric_port"`
+	MetricPath MetricPath `yaml:"metric_path"`
+	Tags       string     `yaml:"tags"`
+	LabelTags  string     `yaml:"label_tags"`
+}
+
+type Selectors struct {
+	Label string `yaml:"label"`
+	Field string `yaml:"field"`
+}
+
+type Control struct {
+	Annotation string `yaml:"annotation"`
+	Label      string `yaml:"label"`
+	Value      string `yaml:"value"`
+}
+
+type MetricPort struct {
+	Annotation string `yaml:"annotation"`
+	Label      string `yaml:"label"`
+	Value      string `yaml:"value"`
+}
+
+type MetricPath struct {
+	Annotation string `yaml:"annotation"`
+	Label      string `yaml:"label"`
+	Value      string `yaml:"value"`
+}
+
+func New(cfg *config.Cluster, parentLogger zerolog.Logger, check *circonus.Check) (*DC, error) {
+	dc := &DC{
+		config: cfg,
+		check:  check,
+		log:    parentLogger.With().Str("pkg", "dynamic-collectors").Logger(),
+	}
+
+	configFile := cfg.DynamicCollectorFile
+	data, err := ioutil.ReadFile(configFile)
+	if err != nil {
+		return nil, err
+	}
+
+	var cc Collectors
+	if err := yaml.Unmarshal(data, &cc); err != nil {
+		return nil, fmt.Errorf("unable to parse dynamic collectors config (%s): %w", configFile, err)
+	}
+
+	dc.collectors = make([]Collector, 0)
+	for idx, collector := range cc.Collectors {
+		if collector.Disable {
+			continue
+		}
+		if collector.Name == "" {
+			dc.log.Warn().Int("position", idx).Msg("invalid collector, 'name' missing, skipping")
+			continue
+		}
+		if collector.MetricPath.Value == "" && collector.MetricPath.Annotation == "" && collector.MetricPath.Label == "" {
+			collector.MetricPath.Value = "/metrics"
+		}
+		if collector.Schema == "" {
+			collector.Schema = "http"
+		}
+		dc.collectors = append(dc.collectors, collector)
+	}
+
+	if len(dc.collectors) == 0 {
+		return nil, fmt.Errorf("invalid dynamic collectors config (%s) zero collectors defined", configFile)
+	}
+
+	return dc, nil
+}
+
+func (dc *DC) Collect(ctx context.Context, tlsConfig *tls.Config, ts *time.Time) {
+	dc.Lock()
+	if dc.running {
+		dc.log.Warn().Msg("already running")
+		dc.Unlock()
+		return
+	}
+	dc.running = true
+	dc.ts = ts
+	dc.Unlock()
+
+	defer func() {
+		if r := recover(); r != nil {
+			dc.log.Error().Interface("panic", r).Msg("recover")
+			dc.Lock()
+			dc.running = false
+			dc.Unlock()
+		}
+	}()
+
+	collectStart := time.Now()
+	var wg sync.WaitGroup
+
+	for _, collector := range dc.collectors {
+		switch strings.ToLower(collector.Type) {
+		case "endpoints":
+			wg.Add(1)
+			go func(collector Collector) {
+				dc.collectEndpoints(ctx, collector)
+				wg.Done()
+			}(collector)
+		case "nodes":
+			wg.Add(1)
+			go func(collector Collector) {
+				dc.collectNodes(ctx, collector)
+				wg.Done()
+			}(collector)
+		case "pods":
+			wg.Add(1)
+			go func(collector Collector) {
+				dc.collectPods(ctx, collector)
+				wg.Done()
+			}(collector)
+		case "services":
+			wg.Add(1)
+			go func(collector Collector) {
+				dc.collectServices(ctx, collector)
+				wg.Done()
+			}(collector)
+		default:
+			dc.log.Warn().Str("name", collector.Name).Str("type", collector.Type).Msg("unknown/unsupported collector type, skipping")
+		}
+	}
+
+	wg.Wait()
+
+	dc.check.AddHistSample("collect_latency", cgm.Tags{
+		cgm.Tag{Category: "source", Value: release.NAME},
+		cgm.Tag{Category: "op", Value: "collect_dynamic-collectors"},
+		cgm.Tag{Category: "units", Value: "milliseconds"},
+	}, float64(time.Since(collectStart).Milliseconds()))
+
+	dc.log.Debug().Str("duration", time.Since(collectStart).String()).Msg("dynamic-collectors collect end")
+	dc.Lock()
+	dc.running = false
+	dc.Unlock()
+}
+
+type metricTarget struct {
+	URL  string
+	Tags []string
+}
+
+func (dc *DC) collectEndpoints(ctx context.Context, collector Collector) {
+	logger := dc.log.With().Str("collector-type", collector.Type).Str("collector-name", collector.Name).Logger()
+
+	clientset, err := k8s.GetClient(dc.config)
+	if err != nil {
+		logger.Warn().Err(err).Msg("initializing k8s client")
+		return
+	}
+
+	opts := metav1.ListOptions{}
+	if collector.Selectors.Field != "" {
+		opts.FieldSelector = collector.Selectors.Field
+	}
+	if collector.Selectors.Label != "" {
+		opts.LabelSelector = collector.Selectors.Label
+	}
+
+	endpoints, err := clientset.CoreV1().Endpoints("").List(opts)
+	if err != nil {
+		logger.Warn().Err(err).Msg("querying k8s endpoints")
+		return
+	}
+
+	targets := make([]metricTarget, 0)
+	for _, item := range endpoints.Items {
+		if !dc.collectItem(collector, item.Labels, item.Annotations) {
+			continue
+		}
+		port := dc.getPort(collector, item.Labels, item.Annotations)
+		if port == "" {
+			logger.Warn().Str("endpoint", item.Name).Interface("collector", collector).Msg("unable to find metric port, skipping")
+			continue
+		}
+		path := dc.getPath(collector, item.Labels, item.Annotations)
+		if path == "" {
+			logger.Warn().Str("endpoint", item.Name).Interface("collector", collector).Msg("unable to find metric path, skipping")
+			continue
+		}
+
+		for _, subset := range item.Subsets {
+			for _, addr := range subset.Addresses {
+				u := url.URL{
+					Scheme: collector.Schema,
+					Host:   addr.IP + ":" + port,
+					Path:   path,
+				}
+				tags := generateTags(collector.Tags, collector.LabelTags, item.Labels)
+				tags = append(tags, "collector_target:"+addr.TargetRef.Name)
+				targets = append(targets, metricTarget{URL: u.String(), Tags: tags})
+			}
+		}
+
+		if done(ctx) {
+			return
+		}
+	}
+
+	for _, target := range targets {
+		dc.getMetrics(ctx, collector, target, logger)
+		if done(ctx) {
+			return
+		}
+	}
+}
+
+func (dc *DC) collectNodes(ctx context.Context, collector Collector) {
+	logger := dc.log.With().Str("collector-type", collector.Type).Str("collector-name", collector.Name).Logger()
+
+	clientset, err := k8s.GetClient(dc.config)
+	if err != nil {
+		logger.Warn().Err(err).Msg("initializing k8s client")
+		return
+	}
+
+	opts := metav1.ListOptions{}
+	if collector.Selectors.Field != "" {
+		opts.FieldSelector = collector.Selectors.Field
+	}
+	if collector.Selectors.Label != "" {
+		opts.LabelSelector = collector.Selectors.Label
+	}
+
+	nodes, err := clientset.CoreV1().Nodes().List(opts)
+	if err != nil {
+		logger.Warn().Err(err).Msg("querying k8s nodes")
+		return
+	}
+
+	targets := make([]metricTarget, 0)
+	for _, item := range nodes.Items {
+		if !dc.collectItem(collector, item.Labels, item.Annotations) {
+			continue
+		}
+		port := dc.getPort(collector, item.Labels, item.Annotations)
+		if port == "" {
+			logger.Warn().Str("node", item.Name).Interface("collector", collector).Msg("unable to find metric port, skipping")
+			continue
+		}
+		path := dc.getPath(collector, item.Labels, item.Annotations)
+		if path == "" {
+			logger.Warn().Str("node", item.Name).Interface("collector", collector).Msg("unable to find metric path, skipping")
+			continue
+		}
+
+		ip := ""
+		for _, addr := range item.Status.Addresses {
+			if addr.Type == v1.NodeInternalIP {
+				ip = addr.Address
+			}
+		}
+		if ip == "" {
+			logger.Warn().Str("node", item.Name).Msg("no internal IP found, skipping")
+			continue
+		}
+
+		u := url.URL{
+			Scheme: collector.Schema,
+			Host:   ip + ":" + port,
+			Path:   path,
+		}
+		tags := generateTags(collector.Tags, collector.LabelTags, item.Labels)
+		tags = append(tags, "collector_target:"+item.Name)
+		targets = append(targets, metricTarget{URL: u.String(), Tags: tags})
+
+		if done(ctx) {
+			return
+		}
+	}
+
+	for _, target := range targets {
+		dc.getMetrics(ctx, collector, target, logger)
+		if done(ctx) {
+			return
+		}
+	}
+}
+
+func (dc *DC) collectPods(ctx context.Context, collector Collector) {
+	logger := dc.log.With().Str("collector-type", collector.Type).Str("collector-name", collector.Name).Logger()
+
+	clientset, err := k8s.GetClient(dc.config)
+	if err != nil {
+		logger.Warn().Err(err).Msg("initializing k8s client")
+		return
+	}
+
+	opts := metav1.ListOptions{}
+	if collector.Selectors.Field != "" {
+		opts.FieldSelector = collector.Selectors.Field
+	}
+	if collector.Selectors.Label != "" {
+		opts.LabelSelector = collector.Selectors.Label
+	}
+
+	pods, err := clientset.CoreV1().Pods("").List(opts)
+	if err != nil {
+		logger.Warn().Err(err).Msg("querying k8s pods")
+		return
+	}
+
+	targets := make([]metricTarget, 0)
+	for _, item := range pods.Items {
+		if !dc.collectItem(collector, item.Labels, item.Annotations) {
+			continue
+		}
+		port := dc.getPort(collector, item.Labels, item.Annotations)
+		if port == "" {
+			logger.Warn().Str("pod", item.Name).Interface("collector", collector).Msg("unable to find metric port, skipping")
+			continue
+		}
+		path := dc.getPath(collector, item.Labels, item.Annotations)
+		if path == "" {
+			logger.Warn().Str("pod", item.Name).Interface("collector", collector).Msg("unable to find metric path, skipping")
+			continue
+		}
+
+		ip := item.Status.PodIP
+		if ip == "" {
+			logger.Warn().Str("pod", item.Name).Msg("no Pod IP found, skipping")
+			continue
+		}
+
+		u := url.URL{
+			Scheme: collector.Schema,
+			Host:   ip + ":" + port,
+			Path:   path,
+		}
+		tags := generateTags(collector.Tags, collector.LabelTags, item.Labels)
+		tags = append(tags, "collector_target:"+item.Name)
+		targets = append(targets, metricTarget{URL: u.String(), Tags: tags})
+
+		if done(ctx) {
+			return
+		}
+	}
+
+	for _, target := range targets {
+		dc.getMetrics(ctx, collector, target, logger)
+		if done(ctx) {
+			return
+		}
+	}
+}
+
+func (dc *DC) collectServices(ctx context.Context, collector Collector) {
+	logger := dc.log.With().Str("collector-type", collector.Type).Str("collector-name", collector.Name).Logger()
+
+	clientset, err := k8s.GetClient(dc.config)
+	if err != nil {
+		logger.Warn().Err(err).Msg("initializing k8s client")
+		return
+	}
+
+	opts := metav1.ListOptions{}
+	if collector.Selectors.Field != "" {
+		opts.FieldSelector = collector.Selectors.Field
+	}
+	if collector.Selectors.Label != "" {
+		opts.LabelSelector = collector.Selectors.Label
+	}
+
+	services, err := clientset.CoreV1().Services("").List(opts)
+	if err != nil {
+		logger.Warn().Err(err).Msg("querying k8s services")
+		return
+	}
+
+	targets := make([]metricTarget, 0)
+	for _, item := range services.Items {
+		if !dc.collectItem(collector, item.Labels, item.Annotations) {
+			continue
+		}
+		port := dc.getPort(collector, item.Labels, item.Annotations)
+		if port == "" {
+			logger.Warn().Str("service", item.Name).Interface("collector", collector).Msg("unable to find metric port, skipping")
+			continue
+		}
+		path := dc.getPath(collector, item.Labels, item.Annotations)
+		if path == "" {
+			logger.Warn().Str("service", item.Name).Interface("collector", collector).Msg("unable to find metric path, skipping")
+			continue
+		}
+
+		ip := item.Spec.ClusterIP
+		if ip == "" || ip == v1.ClusterIPNone {
+			logger.Warn().Str("service", item.Name).Msg("no Cluster IP found, skipping")
+			continue
+		}
+
+		u := url.URL{
+			Scheme: collector.Schema,
+			Host:   ip + ":" + port,
+			Path:   path,
+		}
+		tags := generateTags(collector.Tags, collector.LabelTags, item.Labels)
+		tags = append(tags, "collector_target:"+item.Name)
+		targets = append(targets, metricTarget{URL: u.String(), Tags: tags})
+
+		if done(ctx) {
+			return
+		}
+	}
+
+	for _, target := range targets {
+		dc.getMetrics(ctx, collector, target, logger)
+		if done(ctx) {
+			return
+		}
+	}
+}
+
+// getMetrics fetches the metrics from a url, parses them and submits them to circonus
+func (dc *DC) getMetrics(ctx context.Context, collector Collector, target metricTarget, logger zerolog.Logger) {
+	if done(ctx) {
+		return
+	}
+
+	var data *bytes.Reader
+
+	start := time.Now()
+
+	logger.Debug().Str("url", target.URL).Msg("getting metrics")
+
+	client := &http.Client{}
+	if strings.HasPrefix(target.URL, "https:") {
+		client.Transport = &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}} //nolint:gosec
+	}
+	req, err := http.NewRequestWithContext(ctx, "GET", target.URL, nil)
+	if err != nil {
+		logger.Warn().Err(err).Str("url", target.URL).Msg("creating request")
+		return
+	}
+	req.Header.Add("User-Agent", release.NAME+"/"+release.VERSION)
+	defer client.CloseIdleConnections()
+	resp, err := client.Do(req)
+	if err != nil {
+		dc.check.IncrementCounter("collect_dc_errors", cgm.Tags{
+			cgm.Tag{Category: "source", Value: release.NAME},
+			cgm.Tag{Category: "dcn", Value: collector.Name},
+			cgm.Tag{Category: "request", Value: target.URL},
+		})
+		logger.Warn().Err(err).Str("url", target.URL).Msg("making request")
+		return
+	}
+	defer resp.Body.Close()
+	dc.check.AddHistSample("collect_latency", cgm.Tags{
+		cgm.Tag{Category: "source", Value: release.NAME},
+		cgm.Tag{Category: "dcn", Value: collector.Name},
+		cgm.Tag{Category: "request", Value: target.URL},
+		cgm.Tag{Category: "units", Value: "milliseconds"},
+	}, float64(time.Since(start).Milliseconds()))
+
+	d, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		logger.Error().Err(err).Str("url", target.URL).Msg("reading response")
+		return
+	}
+	if resp.StatusCode != http.StatusOK {
+		dc.check.IncrementCounter("collect_dc_errors", cgm.Tags{
+			cgm.Tag{Category: "source", Value: release.NAME},
+			cgm.Tag{Category: "dcn", Value: collector.Name},
+			cgm.Tag{Category: "request", Value: target.URL},
+			cgm.Tag{Category: "code", Value: fmt.Sprintf("%d", resp.StatusCode)},
+		})
+		logger.Warn().Str("status", resp.Status).RawJSON("response", d).Str("url", target.URL).Msg("error from target")
+		return
+	}
+	data = bytes.NewReader(d)
+	streamTags := []string{
+		"collector:dynamic",
+		"collector_name:" + collector.Name,
+		"collector_type:" + collector.Type,
+		"__rollup:false", // prevent high cardinality metrics from rolling up
+	}
+	streamTags = append(streamTags, target.Tags...)
+	measurementTags := []string{}
+
+	var parser expfmt.TextParser
+	if err := promtext.QueueMetrics(ctx, parser, dc.check, logger, data, streamTags, measurementTags, dc.ts); err != nil {
+		logger.Warn().Err(err).Str("url", target.URL).Msg("parsing metrics")
+		return
+	}
+}
+
+// collectItem uses the configuration's Control settings to determine if the specific item should be collected
+func (dc *DC) collectItem(collector Collector, labels map[string]string, annotations map[string]string) bool {
+	// no annotation or label
+	if collector.Control.Annotation == "" && collector.Control.Label == "" {
+		return true
+	}
+
+	// no value to compare the annotation/label against
+	if collector.Control.Value == "" {
+		return true
+	}
+
+	if collector.Control.Annotation != "" {
+		for an, av := range annotations {
+			if an == collector.Control.Annotation {
+				return av == collector.Control.Value
+			}
+		}
+	}
+
+	if collector.Control.Label != "" {
+		for ln, lv := range labels {
+			if ln == collector.Control.Label {
+				return lv == collector.Control.Value
+			}
+		}
+	}
+
+	return false
+}
+
+// getPort uses the configuration's MetricPort settings to determine what port to use for metric request
+func (dc *DC) getPort(collector Collector, labels map[string]string, annotations map[string]string) string {
+	if collector.MetricPort.Value != "" {
+		return collector.MetricPort.Value
+	}
+
+	if collector.MetricPort.Annotation != "" {
+		for an, av := range annotations {
+			if an == collector.MetricPort.Annotation {
+				return av
+			}
+		}
+	}
+
+	if collector.MetricPort.Label != "" {
+		for ln, lv := range labels {
+			if ln == collector.MetricPort.Label {
+				return lv
+			}
+		}
+	}
+
+	return ""
+}
+
+// getPath uses the configuration's MetricPath settings to determine what path to use for metric request
+func (dc *DC) getPath(collector Collector, labels map[string]string, annotations map[string]string) string {
+	if collector.MetricPath.Value != "" {
+		return collector.MetricPath.Value
+	}
+
+	if collector.MetricPath.Annotation != "" {
+		for an, av := range annotations {
+			if an == collector.MetricPath.Annotation {
+				return av
+			}
+		}
+	}
+
+	if collector.MetricPath.Label != "" {
+		for ln, lv := range labels {
+			if ln == collector.MetricPath.Label {
+				return lv
+			}
+		}
+	}
+
+	return ""
+}
+
+// generateTags creates the initial streamtags for the metric based on configured tags and labels
+func generateTags(tags string, labels string, itemLabels map[string]string) []string {
+	tagList := make([]string, 0)
+	if tags != "" {
+		tt := strings.Split(tags, ",")
+		for _, t := range tt {
+			tagList = append(tagList, strings.TrimSpace(t))
+		}
+	}
+	if labels != "" {
+		ll := strings.Split(labels, ",")
+		for ln, lv := range itemLabels {
+			for _, l := range ll {
+				if strings.TrimSpace(l) == ln {
+					tagList = append(tagList, ln+":"+lv)
+					break
+				}
+			}
+		}
+	}
+	return tagList
+}
+
+func done(ctx context.Context) bool {
+	select {
+	case <-ctx.Done():
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/ksm/ksm.go
+++ b/internal/ksm/ksm.go
@@ -263,7 +263,7 @@ func (ksm *KSM) getMetrics(ctx context.Context, metricURL string) error {
 
 	client := &http.Client{}
 	if strings.HasPrefix(metricURL, "https:") {
-		client.Transport = &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}} //nolint:gosec
+		client.Transport = &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}} //nolint:gosec lgtm[go/disabled-certificate-check]
 	}
 	req, err := http.NewRequestWithContext(ctx, "GET", metricURL, nil)
 	if err != nil {

--- a/internal/ksm/ksm.go
+++ b/internal/ksm/ksm.go
@@ -168,8 +168,9 @@ func (ksm *KSM) Collect(ctx context.Context, tlsConfig *tls.Config, ts *time.Tim
 			if err := ksm.getMetrics(ctx, metricURL); err != nil {
 				ksm.log.Error().Err(err).Interface("address", addr).Str("url", metricURL).Msg("metrics")
 				collectErr++
+			} else {
+				collected++
 			}
-			collected++
 			wg.Done()
 		}(address)
 	}

--- a/internal/ksm/metrics.go
+++ b/internal/ksm/metrics.go
@@ -235,6 +235,10 @@ func (ksm *KSM) queueMetrics(
 
 	if len(metrics) == 0 {
 		srcLogger.Warn().Int("metrics_processed", metricsProcessed).Msg("zero metrics to submit")
+		if metricsProcessed == 0 {
+			// if there are none to send and none were processed, this indicates KSM may be having issues
+			return fmt.Errorf("zero metrics received from KSM - check KSM logs for errors")
+		}
 		return nil
 	}
 

--- a/internal/promtext/promtext.go
+++ b/internal/promtext/promtext.go
@@ -54,11 +54,13 @@ func QueueMetrics(
 
 	metrics := make(map[string]circonus.MetricSample)
 
+	metricsProcessed := 0
 	for mn, mf := range metricFamilies {
 		if done(ctx) {
 			return nil
 		}
 		for _, m := range mf.Metric {
+			metricsProcessed++
 			if done(ctx) {
 				return nil
 			}
@@ -160,6 +162,7 @@ func QueueMetrics(
 	}
 
 	if len(metrics) == 0 {
+		logger.Warn().Int("metrics_processed", metricsProcessed).Msg("zero metrics to submit")
 		return nil
 	}
 


### PR DESCRIPTION
* add: dynamic collectors - define objects (endpoints, nodes, pods, services) to collect metrics from in configuration CIRC-5871
* upd: refactor ksm collection to be more intelligent w/re to port used (not all deployment methods name ports the same) CIRC-5890
* add: static ksm port option to configuration CIRC-5890
* upd: deprecate ksm mode and telemetry port options CIRC-5890
* upd: `pod_pending`, `network_unavailable` and `cpu_utilization` rulesets with `windowing_min_duration` CIRC-5875
* upd: return error when no metrics received from ksm so it can be expose in dashboard
* upd: add check for NaN values (skip) in metric processing
* upd: emit warning when no metrics to submit, with number processed (e.g. locally filtered)
* upd: use epoch for log timestamps (performace)
* upd: refactor cli arg handling
