### PR TITLE
custom/deployment.yaml mismatch with args_kubernetes.go

### DIFF
--- a/deploy/custom/deployment.yaml
+++ b/deploy/custom/deployment.yaml
@@ -199,12 +199,12 @@
                   configMapKeyRef:
                     name: cka-config-v1
                     key: kubernetes-kube-dns-metrics-port
-              - name: CKA_K8S_INCLUDE_CONTAINER_METRICS
+              - name: CKA_K8S_INCLUDE_CONTAINERS
                 valueFrom:
                   configMapKeyRef:
                     name: cka-config-v1
                     key: kubernetes-include-container-metrics
-              - name: CKA_K8S_INCLUDE_POD_METRICS
+              - name: CKA_K8S_INCLUDE_PODS
                 valueFrom:
                   configMapKeyRef:
                     name: cka-config-v1


### PR DESCRIPTION
I was trying to enable container metrics and scratching my head trying to figure out why it wasn't working when I realized the environment variables used in custom/deployment.yaml didn't match the ones in args_kubernetes.go.

It might make more sense on your end to change `args_kubernetes.go` instead, but this at least illustrates the issue.