### PR TITLE
Update GitHub golangci-lint action

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-go@v2
+        with:
+          go-version: '1.17'
       - uses: actions/checkout@v2
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -11,10 +11,8 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: golangci/golangci-lint-action@v3.0.0
-      # - uses: actions/checkout@v2
-      # - name: golangci-lint
-      #   uses: golangci/golangci-lint-action@v2
-      #   with:
-      #     version: v1.41
-      #     args: --timeout=5m
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: latest
+          args: --timeout=5m

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -11,6 +11,8 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/setup-go@v2
+      - uses: actions/checkout@v2
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,22 +1,20 @@
 name: Run golangci-lint
-uses: golangci/golangci-lint-action@v3.0.0
-
-# name: golangci-lint
-# on:
-#   push:
-#     tags:
-#       - v*
-#     branches:
-#       - master
-#   pull_request:
-# jobs:
-#   golangci:
-#     name: lint
-#     runs-on: ubuntu-latest
-#     steps:
-#       - uses: actions/checkout@v2
-#       - name: golangci-lint
-#         uses: golangci/golangci-lint-action@v2
-#         with:
-#           version: v1.41
-#           args: --timeout=5m
+on:
+  push:
+    tags:
+      - v*
+    branches:
+      - master
+  pull_request:
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: golangci/golangci-lint-action@v3.0.0
+      # - uses: actions/checkout@v2
+      # - name: golangci-lint
+      #   uses: golangci/golangci-lint-action@v2
+      #   with:
+      #     version: v1.41
+      #     args: --timeout=5m

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,19 +1,22 @@
-name: golangci-lint
-on:
-  push:
-    tags:
-      - v*
-    branches:
-      - master
-  pull_request:
-jobs:
-  golangci:
-    name: lint
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
-        with:
-          version: v1.41
-          args: --timeout=5m
+- name: Run golangci-lint
+  uses: golangci/golangci-lint-action@v3.0.0
+
+# name: golangci-lint
+# on:
+#   push:
+#     tags:
+#       - v*
+#     branches:
+#       - master
+#   pull_request:
+# jobs:
+#   golangci:
+#     name: lint
+#     runs-on: ubuntu-latest
+#     steps:
+#       - uses: actions/checkout@v2
+#       - name: golangci-lint
+#         uses: golangci/golangci-lint-action@v2
+#         with:
+#           version: v1.41
+#           args: --timeout=5m

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,5 +1,5 @@
-- name: Run golangci-lint
-  uses: golangci/golangci-lint-action@v3.0.0
+name: Run golangci-lint
+uses: golangci/golangci-lint-action@v3.0.0
 
 # name: golangci-lint
 # on:


### PR DESCRIPTION
Update the current action (v2) to the current v3. Add additional required elements to setup go and check out the repository. Set go version to 1.17 and require "latest", set Golang-ci version to "latest".