### PR TITLE
[CIRC-8161] Improve default deployment user experience for recent k8s versions

### DIFF
--- a/deploy/default/authrbac.yaml
+++ b/deploy/default/authrbac.yaml
@@ -1,9 +1,18 @@
 ---
+  ## create namespace
+  apiVersion: v1
+  kind: Namespace
+  metadata:
+    labels:
+      kubernetes.io/metadata.name: circonus-kubernetes-agent
+    name: circonus-kubernetes-agent
+---
   ## create cluster role providing readonly access to resources for collecting metrics
   apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRole
   metadata:
     name: cka-readonly
+    namespace: circonus-kubernetes-agent
     labels:
       app.kubernetes.io/name: circonus-kubernetes-agent
   rules:
@@ -31,7 +40,7 @@
   kind: ServiceAccount
   metadata:
     name: circonus-kubernetes-agent
-    namespace: default
+    namespace: circonus-kubernetes-agent
     labels:
       app.kubernetes.io/name: circonus-kubernetes-agent
 
@@ -41,6 +50,7 @@
   kind: ClusterRoleBinding
   metadata:
     name: cka-readonly
+    namespace: circonus-kubernetes-agent
     labels:
       app.kubernetes.io/name: circonus-kubernetes-agent
   roleRef:
@@ -50,4 +60,4 @@
   subjects:
     - kind: ServiceAccount
       name: circonus-kubernetes-agent
-      namespace: default
+      namespace: circonus-kubernetes-agent

--- a/deploy/default/configuration.yaml
+++ b/deploy/default/configuration.yaml
@@ -9,6 +9,7 @@
     metadata:
       # versioned, cadence independent of app version
       name: cka-secrets-v1
+      namespace: circonus-kubernetes-agent
       labels:
           app.kubernetes.io/name: circonus-kubernetes-agent
     stringData:
@@ -21,6 +22,7 @@
   metadata:
       # versioned, cadence independent of app version
       name: cka-config-v1
+      namespace: circonus-kubernetes-agent
       labels:
           app.kubernetes.io/name: circonus-kubernetes-agent
   data:

--- a/deploy/default/deployment.yaml
+++ b/deploy/default/deployment.yaml
@@ -3,6 +3,7 @@
   kind: Deployment
   metadata:
     name: circonus-kubernetes-agent
+    namespace: circonus-kubernetes-agent
     labels:
       app.kubernetes.io/name: circonus-kubernetes-agent
       app.kubernetes.io/version: latest
@@ -19,10 +20,13 @@
           app.kubernetes.io/name: circonus-kubernetes-agent
           app.kubernetes.io/version: latest
       spec:
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
         serviceAccountName: circonus-kubernetes-agent
         containers:
           - name: circonus-kubernetes-agent
-            image: circonus/circonus-kubernetes-agent:latest
+            image: index.docker.io/circonus/circonus-kubernetes-agent:latest
             command: ["/circonus-kubernetes-agentd"]
             #args: ["--debug"]
             env:


### PR DESCRIPTION

Add namespace resource to default deployment manifests
Fix all namespaced resource manifests to use new namespace in default deployment manifests
Fix issue where agent fails to deploy due to missing SecurityContext in default deployment manifests
(runAsUser and runAsGroup)

issue #CIRC-8161

* Tags: v1.20 namespace securitycontext