### PR TITLE
[CIRC-9164]: Dynamic collector k8s resource field stream tags

### DIFF
--- a/internal/dc/dc.go
+++ b/internal/dc/dc.go
@@ -49,17 +49,18 @@ type Collectors struct {
 }
 
 type Collector struct {
-	MetricPort MetricPort `yaml:"metric_port"`
-	MetricPath MetricPath `yaml:"metric_path"`
-	Schema     Schema     `yaml:"schema"`
-	Rollup     Rollup     `yaml:"rollup"`
-	Control    Control    `yaml:"control"`
-	Selectors  Selectors  `yaml:"selectors"`
-	Type       string     `yaml:"type"`
-	Name       string     `yaml:"name"`
-	Tags       string     `yaml:"tags"`
-	LabelTags  string     `yaml:"label_tags"`
-	Disable    bool       `yaml:"disable"`
+	MetricPort   MetricPort `yaml:"metric_port"`
+	MetricPath   MetricPath `yaml:"metric_path"`
+	Schema       Schema     `yaml:"schema"`
+	Rollup       Rollup     `yaml:"rollup"`
+	Control      Control    `yaml:"control"`
+	Selectors    Selectors  `yaml:"selectors"`
+	Type         string     `yaml:"type"`
+	Name         string     `yaml:"name"`
+	Tags         string     `yaml:"tags"`
+	LabelTags    string     `yaml:"label_tags"`
+	ResourceTags string     `yaml:"resource_tags"`
+	Disable      bool       `yaml:"disable"`
 }
 
 type Selectors struct {


### PR DESCRIPTION
…urce fields

Add field to dynamic collector config for users to configure dynamic collector to pull data from kubernetes resource fields, eg `.spec.nodename`.

issue #CIRC-9164

Enable users to configure dynamic collector to apply stream tags from kubernetes resources.

* Tags: dc config field resource stream