### PR TITLE
v0.19.1

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -105,3 +105,10 @@ release:
 
 checksum: 
   name_template: "{{.ProjectName}}_checksums.txt"
+
+sboms:
+  - artifacts: archive
+    args: ["$artifact", "--output", "cyclonedx-json@1.5=$document"]
+    env:
+      - SYFT_GOLANG_SEARCH_LOCAL_MOD_CACHE_LICENSES=true
+      - SYFT_GOLANG_SEARCH_REMOTE_LICENSES=true

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,13 @@
 project_name: circonus-kubernetes-agent
 
+before:
+  hooks:
+    - go mod tidy
+    - cmd: golangci-lint run
+      env:
+        - GOOS=linux
+    - govulncheck ./...
+
 builds: 
   - id: cka
     main: main.go
@@ -14,6 +22,8 @@ builds:
     ignore: 
       - 
         goarch: 386
+    flags:
+      - -trimpath
     ldflags: 
       - -s
       - -w

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -112,3 +112,8 @@ sboms:
     env:
       - SYFT_GOLANG_SEARCH_LOCAL_MOD_CACHE_LICENSES=true
       - SYFT_GOLANG_SEARCH_REMOTE_LICENSES=true
+
+after:
+  hooks:
+    - cmd: bash -c 'for b in *.sbom; do grype -q --add-cpes-if-none $b; done'
+      dir: ./dist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # **unreleased**
 
+## v0.19.1
+
+* build: add after hook for `grype` on generated sboms
+* build: add .sbom for archive artifacts
+* build: add before hooks for `go mod tidy`, `govulncheck` and `golangci-lint`
+
 ## v0.19.0
 
 * chore(goreleaser): remove archives.rlcp -- deprecated


### PR DESCRIPTION
* build: add after hook for `grype` on generated sboms
* build: add .sbom for archive artifacts
* build: add before hooks for `go mod tidy`, `govulncheck` and `golangci-lint`
